### PR TITLE
AI upgrades

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -250,6 +250,7 @@ type OrchardAiChatFunction {
 type OrchardAiChatMessage {
   content: String!
   role: AiMessageRole!
+  thinking: String
   tool_calls: [OrchardAiChatToolCall!]
 }
 

--- a/schema.gql
+++ b/schema.gql
@@ -28,6 +28,7 @@ input AiChatInput {
 input AiChatMessageInput {
   content: String!
   role: AiMessageRole!
+  thinking: String
 }
 
 enum AiFunctionName {

--- a/schema.gql
+++ b/schema.gql
@@ -63,6 +63,7 @@ enum AiFunctionName {
 
 enum AiMessageRole {
   ASSISTANT
+  ERROR
   FUNCTION
   SYSTEM
   USER

--- a/src/client/modules/ai/ai.module.ts
+++ b/src/client/modules/ai/ai.module.ts
@@ -30,6 +30,7 @@ import {AiChatMessageToolcallComponent} from './components/ai-chat-message-toolc
 import {AiThoughtPipe} from './pipes/ai-thought/ai-thought.pipe';
 import {AiAgentDefinitionComponent} from './components/ai-agent-definition/ai-agent-definition.component';
 import {AiAgentDefinitionToolComponent} from './components/ai-agent-definition-tool/ai-agent-definition-tool.component';
+import {AiChatMessageErrorComponent} from './components/ai-chat-message-error/ai-chat-message-error.component';
 
 @NgModule({
 	declarations: [
@@ -48,6 +49,7 @@ import {AiAgentDefinitionToolComponent} from './components/ai-agent-definition-t
 		AiThoughtPipe,
 		AiAgentDefinitionComponent,
 		AiAgentDefinitionToolComponent,
+		AiChatMessageErrorComponent,
 	],
 	imports: [
 		CommonModule,

--- a/src/client/modules/ai/classes/ai-chat-chunk.class.ts
+++ b/src/client/modules/ai/classes/ai-chat-chunk.class.ts
@@ -7,6 +7,7 @@ interface ParsedOrchardAiChatChunk extends Omit<OrchardAiChatChunk, 'message'> {
 	message: {
 		content: string;
 		role: AiMessageRole;
+		thinking?: string | null;
 		tool_calls?: {
 			function: AiFunction;
 		}[];
@@ -58,11 +59,13 @@ export class AiChatChunk implements ParsedOrchardAiChatChunk {
 export class AiChatMessage implements ParsedOrchardAiChatMessage {
 	public content: string;
 	public role: AiMessageRole;
+	public thinking?: string | null;
 	public tool_calls?: AiChatToolCall[];
 
 	constructor(message: OrchardAiChatMessage) {
 		this.content = message.content;
 		this.role = message.role;
+		this.thinking = message.thinking ?? null;
 		this.tool_calls = message.tool_calls?.map((tool_call: OrchardAiChatToolCall) => new AiChatToolCall(tool_call));
 	}
 }

--- a/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
+++ b/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
@@ -7,6 +7,7 @@ export class AiChatCompiledMessage {
 	public id: string;
 	public id_conversation: string;
 	public content: string;
+	public thinking?: string | null;
 	public role: AiMessageRole;
 	public tool_calls?: AiChatToolCall[];
 	public done: boolean;
@@ -15,6 +16,7 @@ export class AiChatCompiledMessage {
 		this.id = crypto.randomUUID();
 		this.id_conversation = id_conversation;
 		this.content = message.content;
+		this.thinking = message.thinking;
 		this.role = message.role;
 		this.tool_calls = message.tool_calls || [];
 		this.done = false;
@@ -22,6 +24,7 @@ export class AiChatCompiledMessage {
 
 	public integrateChunk(chunk: AiChatChunk): void {
 		this.content += chunk.message.content;
+		if (chunk.message.thinking) this.thinking += chunk.message.thinking;
 		if (chunk.message.tool_calls) this.tool_calls?.push(...chunk.message.tool_calls);
 		if (chunk.done) this.done = true;
 	}
@@ -30,6 +33,7 @@ export class AiChatCompiledMessage {
 		return {
 			role: this.role,
 			content: this.content,
+			thinking: this.thinking,
 		};
 	}
 }

--- a/src/client/modules/ai/components/ai-chat-avatar/ai-chat-avatar.component.scss
+++ b/src/client/modules/ai/components/ai-chat-avatar/ai-chat-avatar.component.scss
@@ -29,3 +29,8 @@
 	background: linear-gradient(to bottom, #fff9a0 0%, #ffe14c 25%, #ff9a3c 50%, #e94e1b 75%, #8c1a1a 100%);
 	@extend %orc-surface-container-high-color;
 }
+
+.avatar-role-error {
+	@extend %orc-error-bg;
+	@extend %orc-on-error-color;
+}

--- a/src/client/modules/ai/components/ai-chat-avatar/ai-chat-avatar.component.ts
+++ b/src/client/modules/ai/components/ai-chat-avatar/ai-chat-avatar.component.ts
@@ -20,6 +20,7 @@ export class AiChatAvatarComponent {
 		[AiMessageRole.User]: 'avatar-role-user',
 		[AiMessageRole.System]: 'avatar-role-system',
 		[AiMessageRole.Function]: 'avatar-role-function',
+		[AiMessageRole.Error]: 'avatar-role-error',
 	};
 
 	public role_class = computed(() => {

--- a/src/client/modules/ai/components/ai-chat-log/ai-chat-log.component.html
+++ b/src/client/modules/ai/components/ai-chat-log/ai-chat-log.component.html
@@ -33,6 +33,9 @@
 							>
 							</orc-ai-chat-message-assistant>
 						}
+						@case ('ERROR') {
+							<orc-ai-chat-message-error [message]="message"> </orc-ai-chat-message-error>
+						}
 					}
 				}
 			</div>

--- a/src/client/modules/ai/components/ai-chat-message-assistant/ai-chat-message-assistant.component.ts
+++ b/src/client/modules/ai/components/ai-chat-message-assistant/ai-chat-message-assistant.component.ts
@@ -73,12 +73,26 @@ export class AiChatMessageAssistantComponent implements OnChanges {
 	constructor(private readonly cdr: ChangeDetectorRef) {}
 
 	ngOnChanges(changes: SimpleChanges): void {
-		if (changes['revision']) {
-			this.parseRawContent();
-		}
+		if (changes['revision']) this.parseRawContent();
 	}
 
 	private async parseRawContent(): Promise<void> {
+		if (this.message.thinking) return this.parseNewThinkingContent();
+		return this.parseLegacyThinkingContent();
+	}
+
+	private async parseNewThinkingContent(): Promise<void> {
+		if (!this.message?.thinking) return;
+		if (!this.think_start) this.think_start = Date.now();
+		this.marked_thinking_content = await this.updateMarkedContent(this.message.thinking);
+		this.marked_content = await this.updateMarkedContent(this.message.content);
+		if (this.message.done) {
+			this.think_end = Date.now();
+			this.finalizeMessage();
+		}
+	}
+
+	private async parseLegacyThinkingContent(): Promise<void> {
 		if (!this.message?.content) return;
 		const content = this.message.content;
 		const think_start = content.indexOf('<think>');

--- a/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.html
+++ b/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.html
@@ -1,0 +1,8 @@
+<div class="ai-chat-message-error-container">
+	<div class="orc-ai-chat-message">
+		<orc-ai-chat-avatar [role]="message.role" [icon]="'error'"></orc-ai-chat-avatar>
+		<div class="orc-ai-chat-message-content error-message">
+			<div class="orc-ai-marked" [innerHTML]="marked_content"></div>
+		</div>
+	</div>
+</div>

--- a/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.scss
+++ b/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.scss
@@ -1,0 +1,5 @@
+@use '@styles/molecule/molecule';
+
+.error-message {
+	@extend %orc-error-color;
+}

--- a/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.spec.ts
+++ b/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.spec.ts
@@ -1,0 +1,22 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {AiChatMessageErrorComponent} from './ai-chat-message-error.component';
+
+describe('AiChatMessageErrorComponent', () => {
+	let component: AiChatMessageErrorComponent;
+	let fixture: ComponentFixture<AiChatMessageErrorComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [AiChatMessageErrorComponent],
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(AiChatMessageErrorComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.ts
+++ b/src/client/modules/ai/components/ai-chat-message-error/ai-chat-message-error.component.ts
@@ -1,0 +1,26 @@
+/* Core Dependencies */
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit} from '@angular/core';
+/* Vendor Dependencies */
+import {marked} from 'marked';
+/* Native Dependencies */
+import {AiChatCompiledMessage} from '@client/modules/ai/classes/ai-chat-compiled-message.class';
+
+@Component({
+	selector: 'orc-ai-chat-message-error',
+	standalone: false,
+	templateUrl: './ai-chat-message-error.component.html',
+	styleUrl: './ai-chat-message-error.component.scss',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AiChatMessageErrorComponent implements OnInit {
+	@Input() public message!: AiChatCompiledMessage;
+
+	public marked_content!: string;
+
+	constructor(private readonly cdr: ChangeDetectorRef) {}
+
+	async ngOnInit(): Promise<void> {
+		this.marked_content = await marked.parse(this.message.content);
+		this.cdr.detectChanges();
+	}
+}

--- a/src/client/modules/ai/services/ai/ai.queries.ts
+++ b/src/client/modules/ai/services/ai/ai.queries.ts
@@ -4,6 +4,7 @@ export const AI_CHAT_SUBSCRIPTION = `
             message {
                 role
                 content
+                thinking
                 tool_calls {
                     function {
                         name

--- a/src/server/modules/ai/ai.enums.ts
+++ b/src/server/modules/ai/ai.enums.ts
@@ -14,6 +14,7 @@ export enum AiMessageRole {
 	ASSISTANT = 'assistant',
 	FUNCTION = 'function',
 	SYSTEM = 'system',
+	ERROR = 'error',
 }
 
 export enum AiFunctionName {

--- a/src/server/modules/ai/ai.types.ts
+++ b/src/server/modules/ai/ai.types.ts
@@ -23,6 +23,7 @@ export type AiModelDetails = {
 export type AiMessage = {
 	role: AiMessageRole;
 	content: string;
+	thinking?: string;
 	tool_calls?: AiToolCall[];
 };
 

--- a/src/server/modules/api/ai/chat/aichat.input.ts
+++ b/src/server/modules/api/ai/chat/aichat.input.ts
@@ -10,6 +10,9 @@ export class AiChatMessageInput {
 
 	@Field()
 	content: string;
+
+	@Field({nullable: true})
+	thinking: string;
 }
 
 @InputType()

--- a/src/server/modules/api/ai/chat/aichat.model.ts
+++ b/src/server/modules/api/ai/chat/aichat.model.ts
@@ -36,12 +36,16 @@ export class OrchardAiChatMessage {
 	@Field()
 	content: string;
 
+	@Field({nullable: true})
+	thinking: string;
+
 	@Field(() => [OrchardAiChatToolCall], {nullable: true})
 	tool_calls: OrchardAiChatToolCall[];
 
 	constructor(message: AiMessage) {
 		this.role = message.role;
 		this.content = message.content;
+		this.thinking = message.thinking;
 		this.tool_calls = message.tool_calls?.map((tool_call: any) => new OrchardAiChatToolCall(tool_call));
 	}
 }

--- a/src/shared/generated.types.ts
+++ b/src/shared/generated.types.ts
@@ -359,6 +359,7 @@ export type OrchardAiChatMessage = {
   __typename?: 'OrchardAiChatMessage';
   content: Scalars['String']['output'];
   role: AiMessageRole;
+  thinking?: Maybe<Scalars['String']['output']>;
   tool_calls?: Maybe<Array<OrchardAiChatToolCall>>;
 };
 

--- a/src/shared/generated.types.ts
+++ b/src/shared/generated.types.ts
@@ -46,6 +46,7 @@ export type AiChatInput = {
 export type AiChatMessageInput = {
   content: Scalars['String']['input'];
   role: AiMessageRole;
+  thinking?: InputMaybe<Scalars['String']['input']>;
 };
 
 export enum AiFunctionName {
@@ -80,6 +81,7 @@ export enum AiFunctionName {
 
 export enum AiMessageRole {
   Assistant = 'ASSISTANT',
+  Error = 'ERROR',
   Function = 'FUNCTION',
   System = 'SYSTEM',
   User = 'USER'


### PR DESCRIPTION
### Add support for new gpt-oss models
The message objects are slightly different for these model types in Ollama. They introduce a new key, thinking. 
Now Orchard supports thinking messages in both the message content via <think> tags, and in the message thinking.

### Add better error handling
Errors thrown by the ollama api are now properly passed back to the client. Important for error messages that explain lack of tool support etc.