### PR TITLE
Fix: Build Optimize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12203,9 +12203,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -17,4 +17,4 @@ async function generateSchema() {
   console.log('Schema generated successfully');
 }
 
-generateSchema();
+generateSchema().then(() => process.exit(0));

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -17,4 +17,9 @@ async function generateSchema() {
   console.log('Schema generated successfully');
 }
 
-generateSchema().then(() => process.exit(0));
+generateSchema()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/server/app.module.ts
+++ b/src/server/app.module.ts
@@ -67,12 +67,12 @@ function initializeGraphQL(configService: ConfigService): ApolloDriverConfig {
 			inject: [ConfigService],
 			useFactory: (configService: ConfigService) => ({
 				type: 'better-sqlite3',
-				database: process.env.SCHEMA_ONLY ? ':memory:' : configService.get('database.path'),
+				database: configService.get('mode.schema_only') ? ':memory:' : configService.get('database.path'),
 				entities: [],
-				synchronize: process.env.SCHEMA_ONLY ? true : configService.get('database.synchronize'),
+				synchronize: configService.get('mode.schema_only') ? true : configService.get('database.synchronize'),
 				autoLoadEntities: true,
-				migrations: process.env.SCHEMA_ONLY ? [] : ['dist/database/migrations/*.js'],
-				migrationsRun: process.env.SCHEMA_ONLY ? false : configService.get('mode.production'),
+				migrations: configService.get('mode.schema_only') ? [] : ['dist/database/migrations/*.js'],
+				migrationsRun: configService.get('mode.schema_only') ? false : configService.get('mode.production'),
 			}),
 			dataSourceFactory: async (options: DataSourceOptions) => {
 				const data_source = new DataSource(options);

--- a/src/server/config/configuration.ts
+++ b/src/server/config/configuration.ts
@@ -41,6 +41,7 @@ export const config = (): Config => {
 	const mode = {
 		production: process.env.NODE_ENV === 'production',
 		dev_auth_bypass: process.env.DEV_AUTH_BYPASS === 'true',
+		schema_only: process.env.SCHEMA_ONLY === 'true',
 		version: `orchard/${process.env['npm_package_version'] || '1.0.0'}`,
 	};
 

--- a/src/server/config/configuration.type.ts
+++ b/src/server/config/configuration.type.ts
@@ -2,6 +2,7 @@ export type Config = {
 	mode: {
 		production: boolean;
 		dev_auth_bypass: boolean;
+		schema_only: boolean;
 		version: string;
 	};
 	server: {

--- a/src/server/modules/ai/agent/agent.service.ts
+++ b/src/server/modules/ai/agent/agent.service.ts
@@ -63,6 +63,7 @@ export class AgentService implements OnModuleInit {
 	) {}
 
 	async onModuleInit(): Promise<void> {
+		if (process.env.SCHEMA_ONLY) return;
 		await this.seedBuiltInAgents();
 		await this.registerAllSchedules();
 	}

--- a/src/server/modules/api/ai/chat/aichat.resolver.ts
+++ b/src/server/modules/api/ai/chat/aichat.resolver.ts
@@ -1,7 +1,6 @@
 /* Core Dependencies */
-import {Logger} from '@nestjs/common';
+import {Logger, OnModuleInit} from '@nestjs/common';
 import {Resolver, Subscription, Args, Mutation} from '@nestjs/graphql';
-import {OnModuleInit} from '@nestjs/common';
 /* Vendor Dependencies */
 import {PubSub} from 'graphql-subscriptions';
 /* Application Dependencies */
@@ -26,6 +25,7 @@ export class AiChatResolver implements OnModuleInit {
 	) {}
 
 	onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.aiChatService.onChatUpdate((chat_chunk: OrchardAiChatChunk) => {
 			pubSub.publish('ai_chat', {ai_chat: chat_chunk});
 		});

--- a/src/server/modules/api/bitcoin/blockchain/btcblockchain.resolver.ts
+++ b/src/server/modules/api/bitcoin/blockchain/btcblockchain.resolver.ts
@@ -17,6 +17,7 @@ export class BitcoinBlockchainResolver {
 	constructor(private bitcoinBlockchainService: BitcoinBlockchainService) {}
 
 	// onModuleInit() {
+	// 	if (process.env.SCHEMA_ONLY) return;
 	// 	this.bitcoinBlockCountService.startBlockCountPolling();
 	// 	this.bitcoinBlockCountService.onBlockCountUpdate((block_count) => {
 	// 		this.logger.debug(`New Block Found!: ${block_count}`);

--- a/src/server/modules/api/bitcoin/oracle/btcoracle.resolver.ts
+++ b/src/server/modules/api/bitcoin/oracle/btcoracle.resolver.ts
@@ -28,6 +28,7 @@ export class BitcoinOracleResolver implements OnModuleInit {
 	) {}
 
 	onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.bitcoinOracleService.onBackfillUpdate((update: OrchardBitcoinOracleBackfillProgress) => {
 			pubSub.publish('bitcoin_oracle_backfill', {bitcoin_oracle_backfill: update});
 		});

--- a/src/server/modules/bitcoin/analytics/btcanalytics.service.ts
+++ b/src/server/modules/bitcoin/analytics/btcanalytics.service.ts
@@ -34,6 +34,7 @@ export class BitcoinAnalyticsService implements OnApplicationBootstrap {
 	) {}
 
 	async onApplicationBootstrap() {
+		if (process.env.SCHEMA_ONLY) return;
 		if (!this.lightningService.isConfigured()) {
 			this.logger.log('Lightning not configured, skipping bitcoin analytics auto-backfill');
 			return;

--- a/src/server/modules/bitcoin/rpc/btcrpc.service.ts
+++ b/src/server/modules/bitcoin/rpc/btcrpc.service.ts
@@ -28,6 +28,7 @@ export class BitcoinRpcService implements OnModuleInit {
 	) {}
 
 	public async onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('bitcoin.type');
 		this.initializeRpc();
 		await this.initializeChain();

--- a/src/server/modules/cashu/mintanalytics/mintanalytics.service.ts
+++ b/src/server/modules/cashu/mintanalytics/mintanalytics.service.ts
@@ -50,6 +50,7 @@ export class CashuMintAnalyticsService implements OnApplicationBootstrap {
 	) {}
 
 	async onApplicationBootstrap() {
+		if (process.env.SCHEMA_ONLY) return;
 		const cashu_type = this.configService.get<string>('cashu.type');
 		if (!cashu_type) {
 			this.logger.log('Cashu not configured, skipping auto-backfill');

--- a/src/server/modules/cashu/mintdb/cashumintdb.service.ts
+++ b/src/server/modules/cashu/mintdb/cashumintdb.service.ts
@@ -50,6 +50,7 @@ export class CashuMintDatabaseService implements OnModuleInit {
 	) {}
 
 	public async onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('cashu.type');
 		this.database = this.configService.get('cashu.database');
 	}

--- a/src/server/modules/cashu/mintrpc/cashumintrpc.service.ts
+++ b/src/server/modules/cashu/mintrpc/cashumintrpc.service.ts
@@ -25,6 +25,7 @@ export class CashuMintRpcService implements OnModuleInit {
 	) {}
 
 	public onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('cashu.type');
 		this.initializeGrpcClient();
 	}

--- a/src/server/modules/lightning/analytics/lnanalytics.service.ts
+++ b/src/server/modules/lightning/analytics/lnanalytics.service.ts
@@ -45,6 +45,7 @@ export class LightningAnalyticsService implements OnApplicationBootstrap {
 	) {}
 
 	async onApplicationBootstrap() {
+		if (process.env.SCHEMA_ONLY) return;
 		if (!this.lightningService.isConfigured()) {
 			this.logger.log('Lightning not configured, skipping auto-backfill');
 			return;

--- a/src/server/modules/lightning/lightning/lightning.service.ts
+++ b/src/server/modules/lightning/lightning/lightning.service.ts
@@ -56,6 +56,7 @@ export class LightningService implements OnModuleInit {
 	) {}
 
 	public async onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('lightning.type');
 		this.initializeGrpcClients();
 	}

--- a/src/server/modules/lightning/walletkit/lnwalletkit.service.ts
+++ b/src/server/modules/lightning/walletkit/lnwalletkit.service.ts
@@ -23,6 +23,7 @@ export class LightningWalletKitService implements OnModuleInit {
 	) {}
 
 	public async onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('lightning.type');
 		this.initializeGrpcClients();
 	}

--- a/src/server/modules/message/telegram/telegram.service.ts
+++ b/src/server/modules/message/telegram/telegram.service.ts
@@ -32,6 +32,7 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
 	******************************************************** */
 
 	async onModuleInit(): Promise<void> {
+		if (process.env.SCHEMA_ONLY) return;
 		await this.initializeBot();
 	}
 

--- a/src/server/modules/setting/setting.service.ts
+++ b/src/server/modules/setting/setting.service.ts
@@ -33,6 +33,7 @@ export class SettingService implements OnModuleInit {
 	 * This ensures all required settings exist in the database
 	 */
 	async onModuleInit(): Promise<void> {
+		if (process.env.SCHEMA_ONLY) return;
 		this.initializeEncryption();
 		await this.initializeDefaults();
 	}

--- a/src/server/modules/tapass/tapass/tapass.service.ts
+++ b/src/server/modules/tapass/tapass/tapass.service.ts
@@ -21,6 +21,7 @@ export class TaprootAssetsService implements OnModuleInit {
 	) {}
 
 	public async onModuleInit() {
+		if (process.env.SCHEMA_ONLY) return;
 		this.type = this.configService.get('taproot_assets.type');
 		this.initializeGrpcClients();
 	}

--- a/src/server/test/schema-guard.spec.ts
+++ b/src/server/test/schema-guard.spec.ts
@@ -1,0 +1,53 @@
+/* Core Dependencies */
+import {readdirSync, readFileSync, statSync} from 'fs';
+import {join} from 'path';
+
+/**
+ * Ensures every onModuleInit / onApplicationBootstrap implementation
+ * contains a SCHEMA_ONLY early-return guard.
+ *
+ * During schema generation the app boots with SCHEMA_ONLY=true.
+ * Services that run init logic (gRPC connections, backfills, etc.)
+ * must check this flag and return early, otherwise the build can
+ * hang or consume excessive memory on constrained hosts.
+ */
+describe('SCHEMA_ONLY guard', () => {
+	const MODULES_DIR = join(__dirname, '..', 'modules');
+	const HOOK_PATTERN = /(?:async\s+)?(?:public\s+)?(?:async\s+)?on(?:ModuleInit|ApplicationBootstrap)\s*\(/;
+	const GUARD_PATTERN = /process\.env\.SCHEMA_ONLY/;
+
+	/** Recursively collect all .ts files (excluding specs and node_modules) */
+	function walk(dir: string): string[] {
+		const results: string[] = [];
+		for (const entry of readdirSync(dir)) {
+			const full = join(dir, entry);
+			if (statSync(full).isDirectory()) {
+				results.push(...walk(full));
+			} else if (full.endsWith('.ts') && !full.endsWith('.spec.ts') && !full.endsWith('.d.ts')) {
+				results.push(full);
+			}
+		}
+		return results;
+	}
+
+	it('all lifecycle init hooks must guard against SCHEMA_ONLY', () => {
+		const files = walk(MODULES_DIR);
+		const missing: string[] = [];
+
+		for (const file of files) {
+			const content = readFileSync(file, 'utf-8');
+			if (HOOK_PATTERN.test(content) && !GUARD_PATTERN.test(content)) {
+				const relative = file.replace(join(__dirname, '..', '..', '..') + '/', '');
+				missing.push(relative);
+			}
+		}
+
+		if (missing.length > 0) {
+			throw new Error(
+				`The following files implement onModuleInit or onApplicationBootstrap without a SCHEMA_ONLY guard:\n\n` +
+					missing.map((f) => `  - ${f}`).join('\n') +
+					`\n\nAdd \`if (process.env.SCHEMA_ONLY) return;\` as the first line of the hook.`,
+			);
+		}
+	});
+});

--- a/src/server/test/schema-guard.spec.ts
+++ b/src/server/test/schema-guard.spec.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {readdirSync, readFileSync, statSync} from 'fs';
+import {readdirSync, readFileSync} from 'fs';
 import {join} from 'path';
 
 /**
@@ -19,11 +19,11 @@ describe('SCHEMA_ONLY guard', () => {
 	/** Recursively collect all .ts files (excluding specs and node_modules) */
 	function walk(dir: string): string[] {
 		const results: string[] = [];
-		for (const entry of readdirSync(dir)) {
-			const full = join(dir, entry);
-			if (statSync(full).isDirectory()) {
+		for (const entry of readdirSync(dir, {withFileTypes: true})) {
+			const full = join(dir, entry.name);
+			if (entry.isDirectory()) {
 				results.push(...walk(full));
-			} else if (full.endsWith('.ts') && !full.endsWith('.spec.ts') && !full.endsWith('.d.ts')) {
+			} else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts') && !entry.name.endsWith('.d.ts')) {
 				results.push(full);
 			}
 		}


### PR DESCRIPTION
## New Features

- **Schema-only init guards** — All `onModuleInit` and `onApplicationBootstrap` hooks now early-return when `SCHEMA_ONLY=true`, preventing gRPC connections, backfills, and bot initialization during schema generation
- **Schema guard test** — New spec ensures every lifecycle init hook includes the `SCHEMA_ONLY` guard, catching future regressions automatically

## Changes

- **SCHEMA_ONLY promoted to typed config** — Replaced raw `process.env.SCHEMA_ONLY` checks in `app.module.ts` with `configService.get('mode.schema_only')` for database configuration
- **Schema generation process exit** — `generate-schema.ts` now properly exits with code 0 on success or code 1 on error, preventing the process from hanging

## Bug Fixes

- **Schema gen error handling** — Errors during schema generation are now caught, logged, and cause a non-zero exit instead of silently hanging
- **Import cleanup** — Consolidated duplicate `@nestjs/common` imports in `aichat.resolver.ts`

## Maintenance

- **npm audit fix** — Patched vulnerable dependencies via `npm audit fix`
