### PR TITLE
chore: Websockets Upgraded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13035,9 +13035,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17930,9 +17930,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "graphql": "^16.13.2",
         "graphql-subscriptions": "^3.0.0",
         "graphql-tools": "^9.0.26",
+        "graphql-ws": "^6.0.8",
         "luxon": "^3.7.2",
         "marked": "^17.0.5",
         "ng2-charts": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "graphql": "^16.13.2",
     "graphql-subscriptions": "^3.0.0",
     "graphql-tools": "^9.0.26",
+    "graphql-ws": "^6.0.8",
     "luxon": "^3.7.2",
     "marked": "^17.0.5",
     "ng2-charts": "^10.0.0",

--- a/src/client/modules/ai/services/ai/ai.service.ts
+++ b/src/client/modules/ai/services/ai/ai.service.ts
@@ -3,15 +3,13 @@ import {Injectable, signal, computed} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Router} from '@angular/router';
 /* Vendor Dependencies */
-import {Observable, catchError, Subscription, Subject, BehaviorSubject, of, map, tap, throwError, shareReplay, finalize} from 'rxjs';
+import {Observable, catchError, Subject, BehaviorSubject, of, map, tap, throwError, shareReplay, finalize} from 'rxjs';
 /* Application Dependencies */
 import {CacheService} from '@client/modules/cache/services/cache/cache.service';
 import {ApiService} from '@client/modules/api/services/api/api.service';
 import {SettingDeviceService} from '@client/modules/settings/services/setting-device/setting-device.service';
-import {LocalStorageService} from '@client/modules/cache/services/local-storage/local-storage.service';
 import {AuthService} from '@client/modules/auth/services/auth/auth.service';
-import {OrchardWsRes} from '@client/modules/api/types/api.types';
-import {getApiQuery} from '@client/modules/api/helpers/api.helpers';
+import {getApiQuery, hasGqlWsErrorCode} from '@client/modules/api/helpers/api.helpers';
 import {OrchardErrors} from '@client/modules/error/classes/error.class';
 import {OrchardRes} from '@client/modules/api/types/api.types';
 /* Native Dependencies */
@@ -81,7 +79,7 @@ export class AiService {
 		return this.assistant_subject.asObservable();
 	}
 
-	private subscription?: Subscription;
+	private dispose_subscription?: () => void;
 	private subscription_id?: string | null;
 	private conversation_subject = new Subject<AiChatConversation | null>();
 	private message_subject = new Subject<AiChatChunk>();
@@ -103,7 +101,6 @@ export class AiService {
 		private cacheService: CacheService,
 		private apiService: ApiService,
 		private settingDeviceService: SettingDeviceService,
-		private localStorageService: LocalStorageService,
 		private authService: AuthService,
 		private router: Router,
 		private http: HttpClient,
@@ -146,54 +143,37 @@ export class AiService {
 		const ai_model = this.settingDeviceService.getModel();
 		this.subscription_id = subscription_id;
 		this.active_subject.next(true);
-		this.subscription = this.apiService.gql_socket.subscribe({
-			next: (response: OrchardWsRes<AiChatResponse>) => {
-				if (response.type === 'data' && response.payload?.errors) {
-					const has_auth_error = response.payload.errors.some((err: any) => err.extensions?.code === 10002);
-					if (has_auth_error) {
-						this.closeAiSocket();
-						this.retryAiSocket(assistant, content, context);
-						return;
-					}
-				}
-				if (response.type === 'data' && response?.payload?.data?.ai_chat) {
-					const chunk = new AiChatChunk(response.payload.data.ai_chat, subscription_id);
-					this.message_subject.next(chunk);
-					chunk.message.tool_calls?.forEach((tool_call) => this.toolcall_subject.next(tool_call));
-					if (chunk.done) this.closeAiSocket();
-				}
-			},
-			error: (error) => {
-				console.error('Socket error:', error);
-				this.subscription_id = null;
-				this.active_subject.next(false);
-			},
-		});
 
 		const conversation = !this.conversation_cache
 			? this.createConversation(subscription_id, assistant, content, context)
 			: this.continueConversation(subscription_id, assistant, content, context);
 		this.conversation_subject.next(conversation);
 		const messages = conversation.getMessages();
-		const auth_token = this.localStorageService.getAuthToken();
 
-		this.apiService.gql_socket.next({type: 'connection_init', payload: {}});
-		this.apiService.gql_socket.next({
-			id: subscription_id,
-			type: 'start',
-			payload: {
-				query: AI_CHAT_SUBSCRIPTION,
-				variables: {
-					ai_chat: {
-						id: subscription_id,
-						messages,
-						model: ai_model,
-						assistant: assistant,
-						auth: auth_token,
-					},
+		this.dispose_subscription = this.apiService.gql_client.subscribe<AiChatResponse>(
+			getApiQuery(AI_CHAT_SUBSCRIPTION, {
+				ai_chat: {id: subscription_id, messages, model: ai_model, assistant},
+			}),
+			{
+				next: (response) => {
+					if (!response.data?.ai_chat) return;
+					const chunk = new AiChatChunk(response.data.ai_chat, subscription_id);
+					this.message_subject.next(chunk);
+					chunk.message.tool_calls?.forEach((tool_call) => this.toolcall_subject.next(tool_call));
+					if (chunk.done) this.closeAiSocket();
 				},
+				error: (error) => {
+					if (hasGqlWsErrorCode(error, 10002)) {
+						this.closeAiSocket();
+						this.retryAiSocket(assistant, content, context);
+						return;
+					}
+					console.error('Socket error:', error);
+					this.closeAiSocket();
+				},
+				complete: () => this.closeAiSocket(),
 			},
-		});
+		);
 	}
 
 	public abortAiSocket(id?: string): void {
@@ -219,14 +199,12 @@ export class AiService {
 	}
 
 	private closeAiSocket(): void {
-		if (!this.subscription) return;
-		this.subscription?.unsubscribe();
-		this.apiService.gql_socket.next({
-			id: this.subscription_id,
-			type: 'stop',
-		});
+		const dispose = this.dispose_subscription;
+		if (!dispose) return;
+		this.dispose_subscription = undefined;
 		this.subscription_id = null;
 		this.active_subject.next(false);
+		dispose();
 	}
 
 	public getAiHealth(): Observable<AiHealth> {

--- a/src/client/modules/api/helpers/api.helpers.spec.ts
+++ b/src/client/modules/api/helpers/api.helpers.spec.ts
@@ -1,0 +1,17 @@
+/* Local Dependencies */
+import {deriveWsScheme} from './api.helpers';
+
+describe('deriveWsScheme', () => {
+	it('returns wss: for https: pages', () => {
+		expect(deriveWsScheme('https:')).toBe('wss:');
+	});
+
+	it('returns ws: for http: pages', () => {
+		expect(deriveWsScheme('http:')).toBe('ws:');
+	});
+
+	it('returns ws: for any non-https scheme (avoids accidental upgrade on file:, chrome-extension:, etc.)', () => {
+		expect(deriveWsScheme('file:')).toBe('ws:');
+		expect(deriveWsScheme('')).toBe('ws:');
+	});
+});

--- a/src/client/modules/api/helpers/api.helpers.spec.ts
+++ b/src/client/modules/api/helpers/api.helpers.spec.ts
@@ -1,5 +1,5 @@
 /* Local Dependencies */
-import {deriveWsScheme} from './api.helpers';
+import {deriveWsScheme, hasGqlWsErrorCode} from './api.helpers';
 
 describe('deriveWsScheme', () => {
 	it('returns wss: for https: pages', () => {
@@ -13,5 +13,25 @@ describe('deriveWsScheme', () => {
 	it('returns ws: for any non-https scheme (avoids accidental upgrade on file:, chrome-extension:, etc.)', () => {
 		expect(deriveWsScheme('file:')).toBe('ws:');
 		expect(deriveWsScheme('')).toBe('ws:');
+	});
+});
+
+describe('hasGqlWsErrorCode', () => {
+	it('returns true when a GraphQL error in the array carries the matching code', () => {
+		expect(hasGqlWsErrorCode([{extensions: {code: 10002}}], 10002)).toBe(true);
+	});
+
+	it('returns false when no error in the array carries the code', () => {
+		expect(hasGqlWsErrorCode([{extensions: {code: 10005}}], 10002)).toBe(false);
+	});
+
+	it('returns false for non-array payloads (CloseEvent, undefined, strings)', () => {
+		expect(hasGqlWsErrorCode(new Event('close'), 10002)).toBe(false);
+		expect(hasGqlWsErrorCode(undefined, 10002)).toBe(false);
+		expect(hasGqlWsErrorCode('error', 10002)).toBe(false);
+	});
+
+	it('tolerates entries missing extensions', () => {
+		expect(hasGqlWsErrorCode([{}, {extensions: {}}], 10002)).toBe(false);
 	});
 });

--- a/src/client/modules/api/helpers/api.helpers.ts
+++ b/src/client/modules/api/helpers/api.helpers.ts
@@ -14,3 +14,9 @@ export function getApiQuery(query: string, variables?: any) {
 export function deriveWsScheme(page_protocol: string): 'ws:' | 'wss:' {
 	return page_protocol === 'https:' ? 'wss:' : 'ws:';
 }
+
+/** Returns true when the graphql-ws error sink payload contains a GraphQL error with `extensions.code === code`. */
+export function hasGqlWsErrorCode(error: unknown, code: number): boolean {
+	if (!Array.isArray(error)) return false;
+	return (error as Array<{extensions?: {code?: number}}>).some((e) => e?.extensions?.code === code);
+}

--- a/src/client/modules/api/helpers/api.helpers.ts
+++ b/src/client/modules/api/helpers/api.helpers.ts
@@ -9,3 +9,8 @@ export function getApiQuery(query: string, variables?: any) {
 		variables: variables,
 	};
 }
+
+/** Derives the WebSocket scheme that matches the page protocol — `wss:` on HTTPS, `ws:` otherwise */
+export function deriveWsScheme(page_protocol: string): 'ws:' | 'wss:' {
+	return page_protocol === 'https:' ? 'wss:' : 'ws:';
+}

--- a/src/client/modules/api/services/api/api.service.spec.ts
+++ b/src/client/modules/api/services/api/api.service.spec.ts
@@ -14,4 +14,10 @@ describe('ApiService', () => {
 	it('should be created', () => {
 		expect(service).toBeTruthy();
 	});
+
+	it('exposes a graphql-ws client with subscribe/dispose', () => {
+		expect(service.gql_client).toBeTruthy();
+		expect(typeof service.gql_client.subscribe).toBe('function');
+		expect(typeof service.gql_client.dispose).toBe('function');
+	});
 });

--- a/src/client/modules/api/services/api/api.service.ts
+++ b/src/client/modules/api/services/api/api.service.ts
@@ -1,9 +1,10 @@
 /* Core Dependencies */
 import {Injectable} from '@angular/core';
 /* Vendor Dependencies */
-import {webSocket, WebSocketSubject} from 'rxjs/webSocket';
+import {Client, createClient} from 'graphql-ws';
 /* Application Dependencies */
 import {ConfigService} from '@client/modules/config/services/config.service';
+import {LocalStorageService} from '@client/modules/cache/services/local-storage/local-storage.service';
 /* Native Dependencies */
 import {deriveWsScheme} from '@client/modules/api/helpers/api.helpers';
 
@@ -11,15 +12,25 @@ import {deriveWsScheme} from '@client/modules/api/helpers/api.helpers';
 	providedIn: 'root',
 })
 export class ApiService {
-	public gql_socket: WebSocketSubject<any>;
+	public gql_client: Client;
 	public api: string;
 
-	constructor(private configService: ConfigService) {
+	constructor(
+		private configService: ConfigService,
+		private localStorageService: LocalStorageService,
+	) {
 		this.api = `${this.configService.config.api.proxy}/${this.configService.config.api.path}`;
 		const ws_scheme = deriveWsScheme(window.location.protocol);
-		this.gql_socket = webSocket({
+		this.gql_client = createClient({
 			url: `${ws_scheme}//${window.location.host}${this.api}`,
-			protocol: 'graphql-ws',
+			/**
+			 * Evaluated each time the socket opens — picks up the latest access token
+			 * from localStorage automatically after a refresh.
+			 */
+			connectionParams: () => ({authorization: this.localStorageService.getAuthToken() ?? ''}),
+			lazy: true,
+			/** Auth-refresh retries are owned by the consuming services; don't double-retry here. */
+			retryAttempts: 0,
 		});
 	}
 }

--- a/src/client/modules/api/services/api/api.service.ts
+++ b/src/client/modules/api/services/api/api.service.ts
@@ -4,6 +4,8 @@ import {Injectable} from '@angular/core';
 import {webSocket, WebSocketSubject} from 'rxjs/webSocket';
 /* Application Dependencies */
 import {ConfigService} from '@client/modules/config/services/config.service';
+/* Native Dependencies */
+import {deriveWsScheme} from '@client/modules/api/helpers/api.helpers';
 
 @Injectable({
 	providedIn: 'root',
@@ -14,8 +16,9 @@ export class ApiService {
 
 	constructor(private configService: ConfigService) {
 		this.api = `${this.configService.config.api.proxy}/${this.configService.config.api.path}`;
+		const ws_scheme = deriveWsScheme(window.location.protocol);
 		this.gql_socket = webSocket({
-			url: `ws://${window.location.host}${this.api}`,
+			url: `${ws_scheme}//${window.location.host}${this.api}`,
 			protocol: 'graphql-ws',
 		});
 	}

--- a/src/client/modules/api/types/api.types.ts
+++ b/src/client/modules/api/types/api.types.ts
@@ -1,20 +1,9 @@
-/* Application Dependencies */
-import {OrchardError} from '@client/modules/error/types/error.types';
 /* Shared Dependencies */
 import {OrchardStatus} from '@shared/generated.types';
 
 export type OrchardRes<T> = {
 	data: T;
 	errors?: {message: string; extensions: {code: number; details?: string}}[];
-};
-
-export type OrchardWsRes<T> = {
-	type: string;
-	payload?: {
-		data: T;
-		errors?: OrchardError[];
-	};
-	id?: string;
 };
 
 export type StatusResponse = {

--- a/src/client/modules/bitcoin/services/bitcoin/bitcoin.queries.ts
+++ b/src/client/modules/bitcoin/services/bitcoin/bitcoin.queries.ts
@@ -125,8 +125,8 @@ query BitcoinOraclePrice($start_date: UnixTimestamp, $end_date: UnixTimestamp) {
 }`;
 
 export const BITCOIN_ORACLE_BACKFILL_SUBSCRIPTION = `
-    subscription BitcoinOracleBackfill($id: String!, $auth: String!, $start_date: UnixTimestamp!, $end_date: UnixTimestamp) {
-        bitcoin_oracle_backfill(id: $id, auth: $auth, start_date: $start_date, end_date: $end_date) {
+    subscription BitcoinOracleBackfill($id: String!, $start_date: UnixTimestamp!, $end_date: UnixTimestamp) {
+        bitcoin_oracle_backfill(id: $id, start_date: $start_date, end_date: $end_date) {
             id
             status
             start_date

--- a/src/client/modules/bitcoin/services/bitcoin/bitcoin.service.ts
+++ b/src/client/modules/bitcoin/services/bitcoin/bitcoin.service.ts
@@ -3,14 +3,13 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Router} from '@angular/router';
 /* Vendor Dependencies */
-import {BehaviorSubject, catchError, map, Observable, of, shareReplay, tap, throwError, Subject, Subscription, finalize} from 'rxjs';
+import {BehaviorSubject, catchError, map, Observable, of, shareReplay, tap, throwError, Subject, finalize} from 'rxjs';
 /* Application Dependencies */
-import {getApiQuery} from '@client/modules/api/helpers/api.helpers';
+import {getApiQuery, hasGqlWsErrorCode} from '@client/modules/api/helpers/api.helpers';
 import {OrchardErrors} from '@client/modules/error/classes/error.class';
-import {OrchardRes, OrchardWsRes} from '@client/modules/api/types/api.types';
+import {OrchardRes} from '@client/modules/api/types/api.types';
 import {CacheService} from '@client/modules/cache/services/cache/cache.service';
 import {ApiService} from '@client/modules/api/services/api/api.service';
-import {LocalStorageService} from '@client/modules/cache/services/local-storage/local-storage.service';
 import {AuthService} from '@client/modules/auth/services/auth/auth.service';
 /* Native Dependencies */
 import {BitcoinBlockCount} from '@client/modules/bitcoin/classes/bitcoin-blockcount.class';
@@ -97,7 +96,7 @@ export class BitcoinService {
 	/* Observables for caching (rapid request caching) */
 	private bitcoin_blockchain_info_observable!: Observable<BitcoinBlockchainInfo> | null;
 	/* Observables for backfill */
-	private backfill_subscription?: Subscription;
+	private backfill_dispose_subscription?: () => void;
 	private backfill_subscription_id?: string | null;
 	private backfill_progress_subject = new Subject<BitcoinOracleBackfillProgress>();
 	private backfill_active_subject = new Subject<boolean>();
@@ -106,7 +105,6 @@ export class BitcoinService {
 		private http: HttpClient,
 		private cache: CacheService,
 		private apiService: ApiService,
-		private localStorageService: LocalStorageService,
 		private authService: AuthService,
 		private router: Router,
 	) {
@@ -367,34 +365,16 @@ export class BitcoinService {
 	 */
 	public openBackfillSocket(start_date: number, end_date?: number | null): void {
 		const subscription_id = crypto.randomUUID();
-		const auth_token = this.localStorageService.getAuthToken();
 		this.backfill_subscription_id = subscription_id;
 		this.backfill_active_subject.next(true);
 
-		this.backfill_subscription = this.apiService.gql_socket.subscribe({
-			next: (response: OrchardWsRes<BitcoinOracleBackfillProgressResponse>) => {
-				if (response.type === 'data' && response.payload?.errors) {
-					const has_throttle_error = response.payload.errors.some((err: any) => err.extensions?.code === 10005);
-					const has_auth_error = response.payload.errors.some((err: any) => err.extensions?.code === 10002);
-					if (has_auth_error) {
-						this.closeBackfillSocket();
-						this.retryBackfillSocket(start_date, end_date);
-						return;
-					}
-					if (has_throttle_error) {
-						const progress = new BitcoinOracleBackfillProgress({
-							id: subscription_id,
-							status: UtxOracleProgressStatus.Error,
-							error: 'Throttle limit reached. Please try again later.',
-						});
-						this.backfill_progress_subject.next(progress);
-						this.closeBackfillSocket();
-						return;
-					}
-				}
-				if (response.type === 'data' && response?.payload?.data?.bitcoin_oracle_backfill) {
-					const progress = new BitcoinOracleBackfillProgress(response.payload.data.bitcoin_oracle_backfill);
-					this.backfill_progress_subject.next(new BitcoinOracleBackfillProgress(progress));
+		this.backfill_dispose_subscription = this.apiService.gql_client.subscribe<BitcoinOracleBackfillProgressResponse>(
+			getApiQuery(BITCOIN_ORACLE_BACKFILL_SUBSCRIPTION, {id: subscription_id, start_date, end_date}),
+			{
+				next: (response) => {
+					if (!response.data?.bitcoin_oracle_backfill) return;
+					const progress = new BitcoinOracleBackfillProgress(response.data.bitcoin_oracle_backfill);
+					this.backfill_progress_subject.next(progress);
 					if (
 						progress.status === UtxOracleProgressStatus.Completed ||
 						progress.status === UtxOracleProgressStatus.Error ||
@@ -402,29 +382,30 @@ export class BitcoinService {
 					) {
 						this.closeBackfillSocket();
 					}
-				}
-			},
-			error: (error) => {
-				console.error('Backfill socket error:', error);
-				this.backfill_subscription_id = null;
-				this.backfill_active_subject.next(false);
-			},
-		});
-
-		this.apiService.gql_socket.next({type: 'connection_init', payload: {}});
-		this.apiService.gql_socket.next({
-			id: subscription_id,
-			type: 'start',
-			payload: {
-				query: BITCOIN_ORACLE_BACKFILL_SUBSCRIPTION,
-				variables: {
-					id: subscription_id,
-					auth: auth_token,
-					start_date: start_date,
-					end_date: end_date,
 				},
+				error: (error) => {
+					if (hasGqlWsErrorCode(error, 10002)) {
+						this.closeBackfillSocket();
+						this.retryBackfillSocket(start_date, end_date);
+						return;
+					}
+					if (hasGqlWsErrorCode(error, 10005)) {
+						this.backfill_progress_subject.next(
+							new BitcoinOracleBackfillProgress({
+								id: subscription_id,
+								status: UtxOracleProgressStatus.Error,
+								error: 'Throttle limit reached. Please try again later.',
+							}),
+						);
+						this.closeBackfillSocket();
+						return;
+					}
+					console.error('Backfill socket error:', error);
+					this.closeBackfillSocket();
+				},
+				complete: () => this.closeBackfillSocket(),
 			},
-		});
+		);
 	}
 
 	public abortBackfillSocket(): void {
@@ -448,18 +429,13 @@ export class BitcoinService {
 			.subscribe();
 	}
 
-	/**
-	 * Close the bitcoin oracle backfill websocket subscription
-	 */
 	private closeBackfillSocket(): void {
-		if (!this.backfill_subscription) return;
-		this.backfill_subscription?.unsubscribe();
-		this.apiService.gql_socket.next({
-			id: this.backfill_subscription_id,
-			type: 'stop',
-		});
+		const dispose = this.backfill_dispose_subscription;
+		if (!dispose) return;
+		this.backfill_dispose_subscription = undefined;
 		this.backfill_subscription_id = null;
 		this.backfill_active_subject.next(false);
+		dispose();
 	}
 
 	/**

--- a/src/server/app.module.ts
+++ b/src/server/app.module.ts
@@ -32,7 +32,6 @@ function initializeGraphQL(configService: ConfigService): ApolloDriverConfig {
 		path: path,
 		subscriptions: {
 			'graphql-ws': true,
-			'subscriptions-transport-ws': false,
 		},
 		resolvers: {
 			UnixTimestamp: UnixTimestamp,

--- a/src/server/modules/api/ai/chat/aichat.input.ts
+++ b/src/server/modules/api/ai/chat/aichat.input.ts
@@ -24,9 +24,6 @@ export class AiChatInput {
 	@Field({description: 'AI model to use for generation'})
 	model: string;
 
-	@Field({description: 'JWT access token for authentication'})
-	auth: string;
-
 	@Field(() => AiAssistant, {nullable: true, description: 'Optional assistant to use'})
 	assistant: AiAssistant | null;
 

--- a/src/server/modules/api/ai/chat/aichat.module.ts
+++ b/src/server/modules/api/ai/chat/aichat.module.ts
@@ -2,14 +2,13 @@
 import {Module} from '@nestjs/common';
 /* Application Dependencies */
 import {ErrorModule} from '@server/modules/error/error.module';
-import {AuthModule} from '@server/modules/auth/auth.module';
 import {AiModule} from '@server/modules/ai/ai.module';
 /* Internal Dependencies */
 import {AiChatResolver} from './aichat.resolver';
 import {AiChatService} from './aichat.service';
 
 @Module({
-	imports: [ErrorModule, AuthModule, AiModule],
+	imports: [ErrorModule, AiModule],
 	providers: [AiChatResolver, AiChatService],
 })
 export class AiChatModule {}

--- a/src/server/modules/api/ai/chat/aichat.resolver.ts
+++ b/src/server/modules/api/ai/chat/aichat.resolver.ts
@@ -3,11 +3,6 @@ import {Logger, OnModuleInit} from '@nestjs/common';
 import {Resolver, Subscription, Args, Mutation} from '@nestjs/graphql';
 /* Vendor Dependencies */
 import {PubSub} from 'graphql-subscriptions';
-/* Application Dependencies */
-import {AuthService} from '@server/modules/auth/auth.service';
-import {NoHeaders} from '@server/modules/auth/decorators/auth.decorator';
-import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
-import {OrchardErrorCode} from '@server/modules/error/error.types';
 /* Local Dependencies */
 import {AiChatService} from './aichat.service';
 import {OrchardAiChatChunk, OrchardAiChatStream} from './aichat.model';
@@ -19,10 +14,7 @@ const pubSub = new PubSub();
 export class AiChatResolver implements OnModuleInit {
 	private readonly logger = new Logger(AiChatResolver.name);
 
-	constructor(
-		private aiChatService: AiChatService,
-		private authService: AuthService,
-	) {}
+	constructor(private aiChatService: AiChatService) {}
 
 	onModuleInit() {
 		if (process.env.SCHEMA_ONLY) return;
@@ -35,15 +27,9 @@ export class AiChatResolver implements OnModuleInit {
 		description: 'Subscribe to AI chat streaming chunks',
 		filter: (payload: {ai_chat: OrchardAiChatChunk}, variables: {ai_chat: AiChatInput}) => payload.ai_chat.id === variables.ai_chat.id,
 	})
-	@NoHeaders()
-	async ai_chat(@Args('ai_chat', {description: 'Chat input with model, messages, and authentication'}) ai_chat: AiChatInput) {
+	async ai_chat(@Args('ai_chat', {description: 'Chat input with model and messages'}) ai_chat: AiChatInput) {
 		const tag = `SUBSCRIPTION { ai_chat } for stream ${ai_chat.id}`;
 		this.logger.debug(tag);
-		try {
-			await this.authService.validateAccessToken(ai_chat.auth);
-		} catch {
-			throw new OrchardApiError(OrchardErrorCode.AuthenticationError);
-		}
 		this.aiChatService.streamChat(tag, ai_chat);
 		return pubSub.asyncIterableIterator('ai_chat');
 	}

--- a/src/server/modules/api/bitcoin/oracle/btcoracle.module.ts
+++ b/src/server/modules/api/bitcoin/oracle/btcoracle.module.ts
@@ -2,7 +2,6 @@
 import {Module} from '@nestjs/common';
 /* Application Dependencies */
 import {ErrorModule} from '@server/modules/error/error.module';
-import {AuthModule} from '@server/modules/auth/auth.module';
 import {BitcoinRpcModule} from '@server/modules/bitcoin/rpc/btcrpc.module';
 import {BitcoinUTXOracleModule} from '@server/modules/bitcoin/utxoracle/utxoracle.module';
 /* Internal Dependencies */
@@ -10,7 +9,7 @@ import {BitcoinOracleResolver} from './btcoracle.resolver';
 import {BitcoinOracleService} from './btcoracle.service';
 
 @Module({
-	imports: [ErrorModule, AuthModule, BitcoinRpcModule, BitcoinUTXOracleModule],
+	imports: [ErrorModule, BitcoinRpcModule, BitcoinUTXOracleModule],
 	providers: [BitcoinOracleResolver, BitcoinOracleService],
 })
 export class BitcoinOracleModule {}

--- a/src/server/modules/api/bitcoin/oracle/btcoracle.resolver.ts
+++ b/src/server/modules/api/bitcoin/oracle/btcoracle.resolver.ts
@@ -5,12 +5,8 @@ import {Throttle, minutes} from '@nestjs/throttler';
 /* Vendor Dependencies */
 import {PubSub} from 'graphql-subscriptions';
 /* Application Dependencies */
-import {AuthService} from '@server/modules/auth/auth.service';
-import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
-import {OrchardErrorCode} from '@server/modules/error/error.types';
 import {Roles} from '@server/modules/auth/decorators/auth.decorator';
 import {UserRole} from '@server/modules/user/user.enums';
-import {NoHeaders} from '@server/modules/auth/decorators/auth.decorator';
 import {UnixTimestamp} from '@server/modules/graphql/scalars/unixtimestamp.scalar';
 /* Local Dependencies */
 import {OrchardBitcoinOraclePrice, OrchardBitcoinOracleBackfillProgress, OrchardBitcoinOracleBackfillStream} from './btcoracle.model';
@@ -22,10 +18,7 @@ const pubSub = new PubSub();
 export class BitcoinOracleResolver implements OnModuleInit {
 	private readonly logger = new Logger(BitcoinOracleResolver.name);
 
-	constructor(
-		private bitcoinOracleService: BitcoinOracleService,
-		private authService: AuthService,
-	) {}
+	constructor(private bitcoinOracleService: BitcoinOracleService) {}
 
 	onModuleInit() {
 		if (process.env.SCHEMA_ONLY) return;
@@ -47,23 +40,14 @@ export class BitcoinOracleResolver implements OnModuleInit {
 
 	@Subscription(() => OrchardBitcoinOracleBackfillProgress, {description: 'Subscribe to Bitcoin oracle backfill progress updates'})
 	@Throttle({default: {limit: 3, ttl: minutes(1)}})
-	@NoHeaders()
+	@Roles(UserRole.ADMIN, UserRole.MANAGER)
 	async bitcoin_oracle_backfill(
 		@Args('id', {type: () => String, description: 'Unique backfill stream identifier'}) id: string,
-		@Args('auth', {type: () => String, description: 'Access token for authentication'}) auth: string,
 		@Args('start_date', {type: () => UnixTimestamp, description: 'Start date for the backfill range'}) start_date: number,
 		@Args('end_date', {type: () => UnixTimestamp, nullable: true, description: 'End date for the backfill range'}) end_date?: number,
 	) {
 		const tag = `SUBSCRIPTION { bitcoin_oracle_backfill } stream ${id}`;
 		this.logger.debug(tag);
-		try {
-			const payload = await this.authService.validateAccessToken(auth);
-			const approved_roles = [UserRole.ADMIN, UserRole.MANAGER];
-			if (!approved_roles.includes(payload.role)) throw new OrchardApiError(OrchardErrorCode.AuthorizationError);
-		} catch (error) {
-			if (error instanceof OrchardApiError) throw error;
-			throw new OrchardApiError(OrchardErrorCode.AuthenticationError);
-		}
 		this.bitcoinOracleService.streamBackfillOracle(tag, id, start_date, end_date);
 		return pubSub.asyncIterableIterator('bitcoin_oracle_backfill');
 	}

--- a/src/server/modules/auth/decorators/auth.decorator.ts
+++ b/src/server/modules/auth/decorators/auth.decorator.ts
@@ -4,8 +4,5 @@ import {UserRole} from '@server/modules/user/user.enums';
 export const PUBLIC_KEY = 'public';
 export const Public = () => SetMetadata(PUBLIC_KEY, true);
 
-export const NO_HEADERS_KEY = 'no_headers';
-export const NoHeaders = () => SetMetadata(NO_HEADERS_KEY, true);
-
 export const ROLES_KEY = 'roles';
 export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/server/modules/auth/guards/authentication.guard.spec.ts
+++ b/src/server/modules/auth/guards/authentication.guard.spec.ts
@@ -3,10 +3,12 @@ import {Test, TestingModule} from '@nestjs/testing';
 import {ExecutionContext} from '@nestjs/common';
 import {Reflector} from '@nestjs/core';
 import {ConfigService} from '@nestjs/config';
+import {GqlExecutionContext} from '@nestjs/graphql';
 import {expect} from '@jest/globals';
 /* Application Dependencies */
 import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
 import {UserRole} from '@server/modules/user/user.enums';
+import {AuthService} from '@server/modules/auth/auth.service';
 /* Local Dependencies */
 import {GqlAuthenticationGuard} from './authentication.guard';
 
@@ -14,6 +16,7 @@ describe('GqlAuthenticationGuard', () => {
 	let guard: GqlAuthenticationGuard;
 	let reflector: jest.Mocked<Reflector>;
 	let configService: jest.Mocked<ConfigService>;
+	let authService: jest.Mocked<AuthService>;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -21,57 +24,112 @@ describe('GqlAuthenticationGuard', () => {
 				GqlAuthenticationGuard,
 				{provide: Reflector, useValue: {getAllAndOverride: jest.fn()}},
 				{provide: ConfigService, useValue: {get: jest.fn()}},
+				{provide: AuthService, useValue: {validateAccessToken: jest.fn()}},
 			],
 		}).compile();
 
 		guard = module.get<GqlAuthenticationGuard>(GqlAuthenticationGuard);
 		reflector = module.get(Reflector);
 		configService = module.get(ConfigService);
+		authService = module.get(AuthService) as jest.Mocked<AuthService>;
 	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	/** Builds a mock ExecutionContext with stubs for the methods the guard calls */
+	const makeContext = () =>
+		({
+			getHandler: jest.fn(),
+			getClass: jest.fn(),
+		}) as unknown as ExecutionContext;
+
+	/** Installs a GqlExecutionContext.create stub that returns an info/context shape */
+	const stubGqlContext = (info: any, req: any) => {
+		jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+			getInfo: () => info,
+			getContext: () => ({req}),
+		} as unknown as GqlExecutionContext);
+	};
 
 	it('should be defined', () => {
 		expect(guard).toBeDefined();
 	});
 
-	it('allows access when route is marked as public', () => {
+	it('allows access when route is marked as public', async () => {
 		reflector.getAllAndOverride.mockReturnValueOnce(true);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		const result = guard.canActivate(context);
+		const result = await guard.canActivate(makeContext());
 
 		expect(result).toBe(true);
 	});
 
-	it('allows access when route is marked as no_headers', () => {
-		reflector.getAllAndOverride.mockReturnValueOnce(false).mockReturnValueOnce(true);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
+	it('validates the subscription token from connectionParams and attaches user', async () => {
+		reflector.getAllAndOverride.mockReturnValueOnce(false);
+		const req: any = {connectionParams: {authorization: 'jwt-access-token'}};
+		stubGqlContext({operation: {operation: 'subscription'}}, req);
+		authService.validateAccessToken.mockResolvedValueOnce({
+			sub: 'user-1',
+			username: 'alice',
+			role: UserRole.ADMIN,
+			type: 'access',
+		} as any);
 
-		const result = guard.canActivate(context);
+		const result = await guard.canActivate(makeContext());
 
 		expect(result).toBe(true);
+		expect(authService.validateAccessToken).toHaveBeenCalledWith('jwt-access-token');
+		expect(req.user).toEqual({id: 'user-1', name: 'alice', role: UserRole.ADMIN, auth_token: 'jwt-access-token'});
+	});
+
+	it('throws AuthenticationError when subscription connectionParams lack a token and dev bypass is off', async () => {
+		reflector.getAllAndOverride.mockReturnValueOnce(false);
+		configService.get.mockReturnValue(false);
+		stubGqlContext({operation: {operation: 'subscription'}}, {connectionParams: {}});
+
+		await expect(guard.canActivate(makeContext())).rejects.toThrow(OrchardApiError);
+		expect(authService.validateAccessToken).not.toHaveBeenCalled();
+	});
+
+	it('returns a dev user for unauthenticated subscriptions when dev bypass is on', async () => {
+		reflector.getAllAndOverride.mockReturnValueOnce(false);
+		configService.get.mockReturnValue(true);
+		const req: any = {connectionParams: {}};
+		stubGqlContext({operation: {operation: 'subscription'}}, req);
+
+		const result = await guard.canActivate(makeContext());
+
+		expect(result).toBe(true);
+		expect(req.user).toEqual({id: 'dev-user', name: 'dev', role: UserRole.ADMIN});
+	});
+
+	it('throws AuthenticationError when the subscription token fails validation', async () => {
+		reflector.getAllAndOverride.mockReturnValueOnce(false);
+		stubGqlContext({operation: {operation: 'subscription'}}, {connectionParams: {authorization: 'bad'}});
+		authService.validateAccessToken.mockRejectedValueOnce(new Error('invalid'));
+
+		await expect(guard.canActivate(makeContext())).rejects.toThrow(OrchardApiError);
 	});
 
 	it('throws OrchardApiError when user is missing and dev_auth_bypass is disabled', () => {
 		configService.get.mockReturnValue(false);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		expect(() => guard.handleRequest(null, null, null, context)).toThrow(OrchardApiError);
+		expect(() => guard.handleRequest(null, null, null, makeContext())).toThrow(OrchardApiError);
 	});
 
 	it('throws OrchardApiError when user is missing and dev_auth_bypass is not set', () => {
 		configService.get.mockReturnValue(undefined);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		expect(() => guard.handleRequest(null, null, null, context)).toThrow(OrchardApiError);
+		expect(() => guard.handleRequest(null, null, null, makeContext())).toThrow(OrchardApiError);
 	});
 
 	it('returns dev user when DEV_AUTH_BYPASS is enabled and no auth header present', () => {
 		configService.get.mockReturnValue(true);
 		const mock_request = {headers: {}};
 		jest.spyOn(guard, 'getRequest').mockReturnValue(mock_request);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		const result = guard.handleRequest(null, null, null, context);
+		const result = guard.handleRequest(null, null, null, makeContext());
 
 		expect(result).toEqual({id: 'dev-user', name: 'dev', role: UserRole.ADMIN});
 	});
@@ -79,17 +137,15 @@ describe('GqlAuthenticationGuard', () => {
 	it('returns user when authentication succeeds', () => {
 		configService.get.mockReturnValue(true);
 		const mock_user = {id: '1', name: 'Alice', role: UserRole.ADMIN};
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		const result = guard.handleRequest(null, mock_user, null, context);
+		const result = guard.handleRequest(null, mock_user, null, makeContext());
 
 		expect(result).toEqual(mock_user);
 	});
 
 	it('throws OrchardApiError when error is present', () => {
 		configService.get.mockReturnValue(true);
-		const context = {getHandler: jest.fn(), getClass: jest.fn()} as unknown as ExecutionContext;
 
-		expect(() => guard.handleRequest(new Error('jwt expired'), null, null, context)).toThrow(OrchardApiError);
+		expect(() => guard.handleRequest(new Error('jwt expired'), null, null, makeContext())).toThrow(OrchardApiError);
 	});
 });

--- a/src/server/modules/auth/guards/authentication.guard.ts
+++ b/src/server/modules/auth/guards/authentication.guard.ts
@@ -8,15 +8,16 @@ import {ConfigService} from '@nestjs/config';
 import {OrchardErrorCode} from '@server/modules/error/error.types';
 import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
 import {UserRole} from '@server/modules/user/user.enums';
+import {AuthService} from '@server/modules/auth/auth.service';
 /* Native Dependencies */
 import {PUBLIC_KEY} from '@server/modules/auth/decorators/auth.decorator';
-import {NO_HEADERS_KEY} from '@server/modules/auth/decorators/auth.decorator';
 
 @Injectable()
 export class GqlAuthenticationGuard extends AuthGuard('jwt') {
 	constructor(
 		private configService: ConfigService,
 		private reflector: Reflector,
+		private authService: AuthService,
 	) {
 		super();
 	}
@@ -25,14 +26,50 @@ export class GqlAuthenticationGuard extends AuthGuard('jwt') {
 		return ctx.getContext().req;
 	}
 
-	canActivate(context: ExecutionContext) {
+	async canActivate(context: ExecutionContext): Promise<boolean> {
 		const is_public = this.reflector.getAllAndOverride<boolean>(PUBLIC_KEY, [context.getHandler(), context.getClass()]);
 		if (is_public) return true;
-		const no_headers = this.reflector.getAllAndOverride<boolean>(NO_HEADERS_KEY, [context.getHandler(), context.getClass()]);
-		if (no_headers) return true;
+
+		const gql_ctx = GqlExecutionContext.create(context);
+		const info = gql_ctx.getInfo?.();
+		const is_subscription = info?.operation?.operation === 'subscription';
+		if (is_subscription) return this.handleSubscription(gql_ctx);
+
 		const request = this.getRequest(context);
 		if (request?.internal && request.user) return true;
-		return super.canActivate(context);
+		return (await super.canActivate(context)) as boolean;
+	}
+
+	/**
+	 * Authenticates a GraphQL subscription by reading the access token from
+	 * the graphql-ws connectionParams, validating it, and attaching a user
+	 * object to the request in the same shape the HTTP passport-jwt path uses.
+	 */
+	private async handleSubscription(gql_ctx: GqlExecutionContext): Promise<boolean> {
+		const request = gql_ctx.getContext().req;
+		const token = request?.connectionParams?.authorization;
+		const dev_auth_bypass = this.configService.get<boolean>('mode.dev_auth_bypass');
+
+		if (!token) {
+			if (dev_auth_bypass) {
+				request.user = {id: 'dev-user', name: 'dev', role: UserRole.ADMIN};
+				return true;
+			}
+			throw new OrchardApiError(OrchardErrorCode.AuthenticationError);
+		}
+
+		try {
+			const payload = await this.authService.validateAccessToken(token);
+			request.user = {
+				id: payload.sub,
+				name: payload.username,
+				role: payload.role,
+				auth_token: token,
+			};
+			return true;
+		} catch {
+			throw new OrchardApiError(OrchardErrorCode.AuthenticationError);
+		}
 	}
 
 	handleRequest(err: any, user: any, _info: any, context: ExecutionContext) {

--- a/src/server/modules/security/security.module.ts
+++ b/src/server/modules/security/security.module.ts
@@ -4,6 +4,7 @@ import {APP_GUARD} from '@nestjs/core';
 import {ConfigService} from '@nestjs/config';
 import {ThrottlerModule} from '@nestjs/throttler';
 /* Application Dependencies */
+import {AuthModule} from '@server/modules/auth/auth.module';
 import {GqlAuthenticationGuard} from '@server/modules/auth/guards/authentication.guard';
 import {GqlAuthorizationGuard} from '@server/modules/auth/guards/authorization.guard';
 /* Local Dependencies */
@@ -11,6 +12,7 @@ import {GqlThrottlerGuard} from './guards/throttler.guard';
 
 @Module({
 	imports: [
+		AuthModule,
 		ThrottlerModule.forRootAsync({
 			inject: [ConfigService],
 			useFactory: (config: ConfigService) => [


### PR DESCRIPTION
## Changes
- **graphql-ws migration** — Replaces the legacy rxjs `WebSocketSubject` + `subscriptions-transport-ws` pipe with the `graphql-ws` client (`createClient`) on the frontend and disables the legacy subprotocol server-side.
- **Centralized subscription auth** — `GqlAuthenticationGuard` now validates subscription access tokens from `connectionParams.authorization` and attaches the user to the request, replacing per-resolver `authService.validateAccessToken` calls and the `@NoHeaders()` escape hatch (decorator removed).
- **Role-based backfill subscription** — `bitcoin_oracle_backfill` now uses `@Roles(ADMIN, MANAGER)` via the guard instead of hand-rolled role checks in the resolver.
- **Schema cleanup** — Drops the per-query `auth: String!` argument from `ai_chat` and `bitcoin_oracle_backfill` subscriptions; removes the now-unused `OrchardWsRes` client type.
- **Service rewrites** — `AiService` and `BitcoinService` are rewritten against `client.subscribe()`, using a shared `hasGqlWsErrorCode` helper for 10002 (auth) and 10005 (throttle) handling and a dispose callback for teardown.

## Bug Fixes
- **HTTPS WebSocket scheme** — Derives the WS scheme from `window.location.protocol` via a new `deriveWsScheme` helper so HTTPS pages get `wss://` instead of the hardcoded `ws://` (which was blocked as mixed content).

## Testing
- **New `api.helpers.spec.ts`** — Covers `deriveWsScheme` (https/http/file/empty) and `hasGqlWsErrorCode` (matching codes, non-array payloads, missing extensions).
- **Expanded `authentication.guard.spec.ts`** — Adds subscription-path coverage: valid token attaches user, missing token throws, missing token with dev bypass returns a dev user, and invalid tokens throw.
- **`api.service.spec.ts`** — Asserts the service exposes a `gql_client` with `subscribe` / `dispose`.