### PR TITLE
chore: non-blocking analytics bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 | -------------- | ---------------------------------- | -------------------------- |
 | Bitcoin        | core (knots compatible)            | (^Satoshi:28.0.0)          |
 | Lightning      | lnd, cln                           | (^v0.19.0-beta), (^v25.02) |
-| Cashu Mint     | cdk, nutshell                      | (^v0.15.1), (^0.19.2)      |
+| Cashu Mint     | cdk, nutshell                      | (^v0.16.0), (^0.20.0)      |
 | Taproot Assets | tapd                               | (^v0.6.1-alpha)            |
-| AI             | ollama                             | (^0.16.2)                  |
+| AI             | ollama                             | (^0.21.0)                  |
 
 <br>
 <br>
@@ -38,7 +38,7 @@
 Always check out the latest release tag before installing or updating. Running from `master` is unsupported and may leave your database in a state that cannot be cleanly upgraded.
 ```bash
 git fetch --tags
-git checkout v1.8.2
+git checkout v1.8.3
 ```
 
 ## Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orchard",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orchard",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^21.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchard",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Web application for Cashu mint management",
   "author": "shyguy",
   "private": true,

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -7,7 +7,7 @@ import { writeFileSync } from 'fs';
 import { AppModule } from '../src/server/app.module';
 
 async function generateSchema() {
-  const app = await NestFactory.create(AppModule, { logger: false });
+  const app = await NestFactory.create(AppModule, { logger: ['error'] });
   await app.init();
 
   const { schema } = app.get(GraphQLSchemaHost);

--- a/src/server/config/configuration.ts
+++ b/src/server/config/configuration.ts
@@ -22,7 +22,7 @@ const getMintRpcMtls = (): boolean => {
 
 export const config = (): Config => {
 	const setup_key = process.env.SETUP_KEY || process.env.ADMIN_PASSWORD;
-	const crypto_key = loadOrCreateCryptoKey();
+	const crypto_key = process.env.SCHEMA_ONLY === 'true' ? '' : loadOrCreateCryptoKey();
 
 	const mode = {
 		production: process.env.NODE_ENV === 'production',

--- a/src/server/modules/bitcoin/analytics/btcanalytics.service.spec.ts
+++ b/src/server/modules/bitcoin/analytics/btcanalytics.service.spec.ts
@@ -81,6 +81,10 @@ describe('BitcoinAnalyticsService', () => {
 		checkpointRepo.findOne.mockResolvedValue(null);
 
 		await service.onApplicationBootstrap();
+		// Bootstrap is fire-and-forget so the port binds immediately; flush microtasks
+		// so the detached backfill promise advances to its first awaited RPC call.
+		await new Promise((resolve) => setImmediate(resolve));
+		await new Promise((resolve) => setImmediate(resolve));
 
 		expect(lightningService.getTransactions).toHaveBeenCalled();
 	});

--- a/src/server/modules/bitcoin/analytics/btcanalytics.service.ts
+++ b/src/server/modules/bitcoin/analytics/btcanalytics.service.ts
@@ -40,11 +40,9 @@ export class BitcoinAnalyticsService implements OnApplicationBootstrap {
 			return;
 		}
 
-		try {
-			await this.runStreamingBackfill();
-		} catch (error) {
+		this.runStreamingBackfill().catch((error) => {
 			this.logger.error('Error during bitcoin analytics auto-backfill', error);
-		}
+		});
 	}
 
 	/* *******************************************************

--- a/src/server/modules/lightning/analytics/lnanalytics.service.ts
+++ b/src/server/modules/lightning/analytics/lnanalytics.service.ts
@@ -51,12 +51,9 @@ export class LightningAnalyticsService implements OnApplicationBootstrap {
 			return;
 		}
 
-		try {
-			// Use streaming backfill which handles checkpoint-based resumption
-			await this.runStreamingBackfill();
-		} catch (error) {
+		this.runStreamingBackfill().catch((error) => {
 			this.logger.error('Error during lightning analytics auto-backfill', error);
-		}
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Changes
- **Non-blocking analytics backfill** — detach streaming backfill in bitcoin and lightning analytics services so `onApplicationBootstrap` returns immediately; port binds and requests are served while backfill runs in the background, with errors still surfaced via `.catch()`.
- **Schema generation hardening** — stub `crypto_key` when `SCHEMA_ONLY=true` so `generate-schema.ts` skips key load/create, and surface errors from the Nest logger (`['error']`) instead of silencing them.
- **Release prep** — bump version to `1.8.3` in `package.json`, `package-lock.json`, and the README install instructions; update documented compatible versions for Cashu Mint (cdk `v0.16.0`, nutshell `0.20.0`) and Ollama (`0.21.0`).

## Testing
- **Bitcoin analytics spec** — flush microtasks after `onApplicationBootstrap` so the detached backfill promise reaches its first awaited RPC before assertions run.
