### PR TITLE
fix: Cdk Timestamps

### DIFF
--- a/src/server/app.module.ts
+++ b/src/server/app.module.ts
@@ -72,6 +72,7 @@ function initializeGraphQL(configService: ConfigService): ApolloDriverConfig {
 				autoLoadEntities: true,
 				migrations: configService.get('mode.schema_only') ? [] : ['dist/database/migrations/*.js'],
 				migrationsRun: configService.get('mode.schema_only') ? false : configService.get('mode.production'),
+				retryAttempts: configService.get('mode.schema_only') ? 0 : 10,
 			}),
 			dataSourceFactory: async (options: DataSourceOptions) => {
 				const data_source = new DataSource(options);

--- a/src/server/modules/cashu/cdk/cdk.service.spec.ts
+++ b/src/server/modules/cashu/cdk/cdk.service.spec.ts
@@ -16,6 +16,7 @@ jest.mock('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
 	queryRows: jest.fn(),
 	queryRow: jest.fn().mockResolvedValue({count: 1}),
 	extractRequestString: jest.fn().mockImplementation((s: string) => s?.replace(/^.*:/, '')),
+	convertDateToUnixTimestamp: jest.fn((v: any) => (typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : null)),
 }));
 import * as helpers from '@server/modules/cashu/mintdb/cashumintdb.helpers';
 
@@ -228,6 +229,172 @@ describe('CdkService', () => {
 			{created_time: 10, keyset_id: 'k1', unit: 'sat', state: 'SPENT', amounts: 'not-json'},
 		]);
 		await expect(cdkService.listProofGroups({} as any)).rejects.toThrow();
+	});
+
+	/* Postgres returns BIGINT columns as strings; CDK service must coerce timestamp fields to numbers so that
+	   downstream consumers (analytics, luxon) receive the declared `number` type. These tests feed string
+	   timestamps to simulate the pg transport and assert the service repairs the type at its boundary. */
+
+	it('listSwaps coerces string created_time from pg BIGINT to number', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{operation_id: 'op1', keyset_ids: 'k1,k2', unit: 'sat', amount: 100, created_time: '1745262864', fee: 0},
+		]);
+		const out = await cdkService.listSwaps({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+	});
+
+	it('listMeltQuotes coerces string created_time and paid_time to number', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{id: 'q1', request: 'bolt11:lnbc', unit: 'sat', state: 'PAID', created_time: '1745262864', paid_time: '1745262900'},
+		]);
+		const out = await cdkService.listMeltQuotes({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+		expect(out[0].paid_time).toBe(1745262900);
+	});
+
+	it('listMeltQuotes preserves null paid_time', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{id: 'q1', request: 'bolt11:lnbc', unit: 'sat', state: 'UNPAID', created_time: 1, paid_time: null},
+		]);
+		const out = await cdkService.listMeltQuotes({} as any);
+		expect(out[0].paid_time).toBeNull();
+	});
+
+	it('listMintQuotes coerces string timestamps and preserves nullable fields', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{
+				id: 'q1',
+				amount: 10,
+				unit: 'sat',
+				request: 'r',
+				state: 'UNPAID',
+				created_time: '1745262864',
+				issued_time: null,
+				paid_time: null,
+			},
+		]);
+		const out = await cdkService.listMintQuotes({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+		expect(out[0].issued_time).toBeNull();
+		expect(out[0].paid_time).toBeNull();
+	});
+
+	it('listProofs coerces string created_time', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{amount: 1, keyset_id: 'k1', unit: 'sat', state: 'SPENT', created_time: '1745262864'},
+		]);
+		const out = await cdkService.listProofs({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+	});
+
+	it('listPromises coerces string created_time', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([{amount: 1, keyset_id: 'k1', unit: 'sat', created_time: '1745262864'}]);
+		const out = await cdkService.listPromises({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+	});
+
+	it('listProofGroups coerces string created_time on the grouped output', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{created_time: '1745262864', keyset_id: 'k1', unit: 'sat', state: 'SPENT', amounts: '[1]'},
+		]);
+		const out = await cdkService.listProofGroups({} as any);
+		expect(typeof out[0].created_time).toBe('number');
+		expect(out[0].created_time).toBe(1745262864);
+	});
+
+	it('listMintQuotes coerces string issued_time and paid_time when non-null', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{
+				id: 'q1',
+				amount: 10,
+				unit: 'sat',
+				request: 'r',
+				state: 'ISSUED',
+				created_time: '1745262864',
+				issued_time: '1745262900',
+				paid_time: '1745262899',
+			},
+		]);
+		const out = await cdkService.listMintQuotes({} as any);
+		expect(typeof out[0].issued_time).toBe('number');
+		expect(out[0].issued_time).toBe(1745262900);
+		expect(typeof out[0].paid_time).toBe('number');
+		expect(out[0].paid_time).toBe(1745262899);
+	});
+
+	it('listMintQuotes treats undefined nullable fields as null', async () => {
+		(helpers.queryRows as jest.Mock).mockResolvedValueOnce([
+			{id: 'q1', amount: 10, unit: 'sat', request: 'r', state: 'UNPAID', created_time: 1},
+		]);
+		const out = await cdkService.listMintQuotes({} as any);
+		expect(out[0].issued_time).toBeNull();
+		expect(out[0].paid_time).toBeNull();
+	});
+
+	it('lookupMintQuote coerces string created_time and returns null when not found', async () => {
+		(helpers.queryRow as jest.Mock).mockResolvedValueOnce({
+			id: 'q1',
+			amount: 10,
+			unit: 'sat',
+			request: 'r',
+			state: 'UNPAID',
+			created_time: '1745262864',
+		});
+		const out = await cdkService.lookupMintQuote({} as any, 'q1');
+		expect(typeof out!.created_time).toBe('number');
+		expect(out!.created_time).toBe(1745262864);
+
+		(helpers.queryRow as jest.Mock).mockResolvedValueOnce(undefined);
+		const missing = await cdkService.lookupMintQuote({} as any, 'missing');
+		expect(missing).toBeNull();
+	});
+
+	it('lookupMeltQuote coerces string timestamps and preserves null paid_time', async () => {
+		(helpers.queryRow as jest.Mock).mockResolvedValueOnce({
+			id: 'q1',
+			unit: 'sat',
+			amount: 10,
+			request: 'r',
+			fee_reserve: 0,
+			state: 'PAID',
+			payment_preimage: null,
+			request_lookup_id: null,
+			msat_to_pay: null,
+			created_time: '1745262864',
+			paid_time: '1745262900',
+			payment_method: 'bolt11',
+		});
+		const out = await cdkService.lookupMeltQuote({} as any, 'q1');
+		expect(typeof out!.created_time).toBe('number');
+		expect(out!.created_time).toBe(1745262864);
+		expect(typeof out!.paid_time).toBe('number');
+		expect(out!.paid_time).toBe(1745262900);
+
+		(helpers.queryRow as jest.Mock).mockResolvedValueOnce({
+			id: 'q2',
+			unit: 'sat',
+			amount: 10,
+			request: 'r',
+			fee_reserve: 0,
+			state: 'UNPAID',
+			payment_preimage: null,
+			request_lookup_id: null,
+			msat_to_pay: null,
+			created_time: 1,
+			paid_time: null,
+			payment_method: 'bolt11',
+		});
+		const unpaid = await cdkService.lookupMeltQuote({} as any, 'q2');
+		expect(unpaid!.paid_time).toBeNull();
+
+		(helpers.queryRow as jest.Mock).mockResolvedValueOnce(undefined);
+		const missing = await cdkService.lookupMeltQuote({} as any, 'missing');
+		expect(missing).toBeNull();
 	});
 
 	it('countMintQuotes and countMeltQuotes return row.count', async () => {

--- a/src/server/modules/cashu/cdk/cdk.service.ts
+++ b/src/server/modules/cashu/cdk/cdk.service.ts
@@ -33,6 +33,7 @@ import {
 	queryRows,
 	queryRow,
 	extractRequestString,
+	convertDateToUnixTimestamp,
 } from '@server/modules/cashu/mintdb/cashumintdb.helpers';
 import {MintDatabaseType} from '@server/modules/cashu/mintdb/cashumintdb.enums';
 /* Local Dependencies */
@@ -223,7 +224,13 @@ export class CdkService {
 			time_is_epoch_seconds: true,
 		});
 		try {
-			return queryRows<CashuMintMintQuote>(client, sql, params);
+			const rows = await queryRows<CashuMintMintQuote>(client, sql, params);
+			return rows.map((row) => ({
+				...row,
+				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+				issued_time: row.issued_time != null ? convertDateToUnixTimestamp(row.issued_time) : null,
+				paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
+			}));
 		} catch (err) {
 			throw err;
 		}
@@ -244,7 +251,8 @@ export class CdkService {
 			FROM mint_quote WHERE id = ?`;
 		try {
 			const row = await queryRow<CashuMintMintQuote | undefined>(client, sql, [quote_id]);
-			return row ?? null;
+			if (!row) return null;
+			return {...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0};
 		} catch (err) {
 			throw err;
 		}
@@ -254,7 +262,12 @@ export class CdkService {
 		const sql = `SELECT * FROM melt_quote WHERE id = ?`;
 		try {
 			const row = await queryRow<CashuMintMeltQuote | undefined>(client, sql, [quote_id]);
-			return row ?? null;
+			if (!row) return null;
+			return {
+				...row,
+				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+				paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
+			};
 		} catch (err) {
 			throw err;
 		}
@@ -278,7 +291,12 @@ export class CdkService {
 			const rows = await queryRows<CashuMintMeltQuote>(client, sql, params);
 			return rows.map((row) => {
 				const s = extractRequestString(row.request);
-				return s ? {...row, request: s} : row;
+				return {
+					...row,
+					request: s ?? row.request,
+					created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+					paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
+				};
 			});
 		} catch (err) {
 			throw err;
@@ -334,8 +352,8 @@ export class CdkService {
 			});
 
 			const proof_groups: CashuMintProofGroup[] = Object.values(groups).map((group: any) => ({
-				amount: group.amounts.flat().reduce((sum, amount) => sum + amount, 0),
-				created_time: group.created_time,
+				amount: group.amounts.flat().reduce((sum: number, amount: number) => sum + amount, 0),
+				created_time: convertDateToUnixTimestamp(group.created_time) ?? 0,
 				keyset_ids: group.keysets,
 				unit: group.unit,
 				state: group.state,
@@ -374,7 +392,8 @@ export class CdkService {
 			select_statement,
 			time_is_epoch_seconds: true,
 		});
-		return queryRows<CashuMintProof>(client, sql, params);
+		const rows = await queryRows<CashuMintProof>(client, sql, params);
+		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0}));
 	}
 
 	public async listPromises(client: CashuMintDatabase, args?: CashuMintPromiseArgs): Promise<CashuMintPromise[]> {
@@ -402,7 +421,8 @@ export class CdkService {
 			select_statement,
 			time_is_epoch_seconds: true,
 		});
-		return queryRows<CashuMintPromise>(client, sql, params);
+		const rows = await queryRows<CashuMintPromise>(client, sql, params);
+		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0}));
 	}
 
 	public async countMintQuotes(client: CashuMintDatabase, args?: CashuMintMintQuotesArgs): Promise<number> {
@@ -542,6 +562,7 @@ export class CdkService {
 			return rows.map((row) => ({
 				...row,
 				keyset_ids: row.keyset_ids ? row.keyset_ids.split(',') : [],
+				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
 			}));
 		} catch (err) {
 			throw err;

--- a/src/server/modules/cashu/cdk/cdk.service.ts
+++ b/src/server/modules/cashu/cdk/cdk.service.ts
@@ -227,7 +227,7 @@ export class CdkService {
 			const rows = await queryRows<CashuMintMintQuote>(client, sql, params);
 			return rows.map((row) => ({
 				...row,
-				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+				created_time: convertDateToUnixTimestamp(row.created_time),
 				issued_time: row.issued_time != null ? convertDateToUnixTimestamp(row.issued_time) : null,
 				paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
 			}));
@@ -252,7 +252,7 @@ export class CdkService {
 		try {
 			const row = await queryRow<CashuMintMintQuote | undefined>(client, sql, [quote_id]);
 			if (!row) return null;
-			return {...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0};
+			return {...row, created_time: convertDateToUnixTimestamp(row.created_time)};
 		} catch (err) {
 			throw err;
 		}
@@ -265,7 +265,7 @@ export class CdkService {
 			if (!row) return null;
 			return {
 				...row,
-				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+				created_time: convertDateToUnixTimestamp(row.created_time),
 				paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
 			};
 		} catch (err) {
@@ -293,8 +293,8 @@ export class CdkService {
 				const s = extractRequestString(row.request);
 				return {
 					...row,
-					request: s ?? row.request,
-					created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+					request: s || row.request,
+					created_time: convertDateToUnixTimestamp(row.created_time),
 					paid_time: row.paid_time != null ? convertDateToUnixTimestamp(row.paid_time) : null,
 				};
 			});
@@ -353,7 +353,7 @@ export class CdkService {
 
 			const proof_groups: CashuMintProofGroup[] = Object.values(groups).map((group: any) => ({
 				amount: group.amounts.flat().reduce((sum: number, amount: number) => sum + amount, 0),
-				created_time: convertDateToUnixTimestamp(group.created_time) ?? 0,
+				created_time: convertDateToUnixTimestamp(group.created_time),
 				keyset_ids: group.keysets,
 				unit: group.unit,
 				state: group.state,
@@ -393,7 +393,7 @@ export class CdkService {
 			time_is_epoch_seconds: true,
 		});
 		const rows = await queryRows<CashuMintProof>(client, sql, params);
-		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0}));
+		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time)}));
 	}
 
 	public async listPromises(client: CashuMintDatabase, args?: CashuMintPromiseArgs): Promise<CashuMintPromise[]> {
@@ -422,7 +422,7 @@ export class CdkService {
 			time_is_epoch_seconds: true,
 		});
 		const rows = await queryRows<CashuMintPromise>(client, sql, params);
-		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time) ?? 0}));
+		return rows.map((row) => ({...row, created_time: convertDateToUnixTimestamp(row.created_time)}));
 	}
 
 	public async countMintQuotes(client: CashuMintDatabase, args?: CashuMintMintQuotesArgs): Promise<number> {
@@ -562,7 +562,7 @@ export class CdkService {
 			return rows.map((row) => ({
 				...row,
 				keyset_ids: row.keyset_ids ? row.keyset_ids.split(',') : [],
-				created_time: convertDateToUnixTimestamp(row.created_time) ?? 0,
+				created_time: convertDateToUnixTimestamp(row.created_time),
 			}));
 		} catch (err) {
 			throw err;


### PR DESCRIPTION
## Bug Fixes
- **CDK timestamp normalization fixes analytics** — route `created_time`, `issued_time`, and `paid_time` through `convertDateToUnixTimestamp` across `listMintQuotes`, `getMintQuote`, `getMeltQuote`, `listMeltQuotes`, `listProofGroups`, `listProofs`, `listPromises`, and `listKeysets` so analytics consumers receive Unix integers instead of Date objects or pg BIGINT strings.
- **Skip DB retries in schema-only mode** — set TypeORM `retryAttempts` to `0` when `mode.schema_only` is active so schema generation doesn't block on repeated connection retries.

## Testing
- **CDK service spec coverage** — add tests asserting pg BIGINT string timestamps get coerced to numbers and nullable fields (`issued_time`, `paid_time`) stay null across `listSwaps`, `listMintQuotes`, `listMeltQuotes`, `listProofs`, `listPromises`, `listProofGroups`, `lookupMintQuote`, and `lookupMeltQuote`.