### PR TITLE
chore: Refresh package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5913,16 +5913,16 @@
       }
     },
     "node_modules/@nestjs/typeorm": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
-      "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
+      "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
+        "typeorm": "^0.3.0 || ^1.0.0-dev"
       }
     },
     "node_modules/@noble/hashes": {
@@ -17765,9 +17765,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Changes
- **Lockfile refresh** — pick up transitive bumps for `@nestjs/typeorm` (11.0.0 → 11.0.1) and `postcss` (8.5.6 → 8.5.10); no `package.json` changes