### PR TITLE
fix: Swap client crypto.randomUUID for uuid

### DIFF
--- a/e2e/helpers/ui/settings.ts
+++ b/e2e/helpers/ui/settings.ts
@@ -120,11 +120,16 @@ async function applyCurrency(page: Page, mode: 'btc' | 'fiat', currency: 'code' 
 
 /** Select an AI model from the mat-autocomplete on the device settings page.
  *  Requires AI to be enabled (app setting) before this page load or the card
- *  won't render. Value is saved to localStorage on option click — no commit. */
+ *  won't render. Asserts the option exists (loud-fail if `AI_MODEL` isn't
+ *  pulled into ollama on this stack) and that the input commits the value. */
 async function applyAiModel(page: Page, model: string): Promise<void> {
-	const input = page.locator('orc-settings-subsection-device-ai').locator('input[aria-label="Model"]');
+	const card = page.locator('orc-settings-subsection-device-ai');
+	const input = card.locator('input[aria-label="Model"]');
 	await input.fill(model);
-	await page.getByRole('option', {name: model, exact: true}).click();
+	const option = page.locator('mat-option').filter({hasText: model});
+	await expect(option, `AI_MODEL "${model}" not present in ollama autocomplete on this stack`).toHaveCount(1);
+	await option.click();
+	await expect(input, `AI_MODEL "${model}" did not commit to the model input`).toHaveValue(model);
 }
 
 async function applyDeviceSettings(page: Page, device: DeviceSettingValues): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "socks-proxy-agent": "^8.0.5",
         "tslib": "^2.8.1",
         "typeorm": "^0.3.28",
+        "uuid": "^14.0.0",
         "zone.js": "~0.16.0"
       },
       "devDependencies": {
@@ -1285,6 +1286,19 @@
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -20643,6 +20657,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/typeorm/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -21014,16 +21041,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "socks-proxy-agent": "^8.0.5",
     "tslib": "^2.8.1",
     "typeorm": "^0.3.28",
+    "uuid": "^14.0.0",
     "zone.js": "~0.16.0"
   },
   "devDependencies": {

--- a/src/client/modules/ai/classes/ai-chat-compiled-message.class.spec.ts
+++ b/src/client/modules/ai/classes/ai-chat-compiled-message.class.spec.ts
@@ -1,0 +1,28 @@
+/* Native Dependencies */
+import {AiChatMessage} from '@client/modules/ai/classes/ai-chat-chunk.class';
+/* Local Dependencies */
+import {AiChatCompiledMessage} from './ai-chat-compiled-message.class';
+/* Shared Dependencies */
+import {AiMessageRole} from '@shared/generated.types';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const message = (): AiChatMessage =>
+	new AiChatMessage({
+		content: 'hi',
+		role: AiMessageRole.Assistant,
+		thinking: null,
+		tool_calls: null,
+	} as any);
+
+describe('AiChatCompiledMessage', () => {
+	it('assigns a v4 uuid as id (works in non-secure-context browsers, unlike crypto.randomUUID)', () => {
+		const compiled = new AiChatCompiledMessage('conv-1', message());
+		expect(compiled.id).toMatch(UUID_V4_REGEX);
+	});
+
+	it('produces a unique id per instance', () => {
+		const ids = new Set(Array.from({length: 100}, () => new AiChatCompiledMessage('conv-1', message()).id));
+		expect(ids.size).toBe(100);
+	});
+});

--- a/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
+++ b/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
@@ -1,7 +1,7 @@
-/* Native Dependencies */
-import {AiChatChunk, AiChatMessage, AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
 /* Vendor Dependencies */
 import {v4 as uuidv4} from 'uuid';
+/* Native Dependencies */
+import {AiChatChunk, AiChatMessage, AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
 /* Shared Dependencies */
 import {AiMessageRole} from '@shared/generated.types';
 

--- a/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
+++ b/src/client/modules/ai/classes/ai-chat-compiled-message.class.ts
@@ -1,5 +1,7 @@
 /* Native Dependencies */
 import {AiChatChunk, AiChatMessage, AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
+/* Vendor Dependencies */
+import {v4 as uuidv4} from 'uuid';
 /* Shared Dependencies */
 import {AiMessageRole} from '@shared/generated.types';
 
@@ -13,7 +15,7 @@ export class AiChatCompiledMessage {
 	public done: boolean;
 
 	constructor(id_conversation: string, message: AiChatMessage) {
-		this.id = crypto.randomUUID();
+		this.id = uuidv4();
 		this.id_conversation = id_conversation;
 		this.content = message.content;
 		this.thinking = message.thinking;

--- a/src/client/modules/ai/services/ai/ai.service.ts
+++ b/src/client/modules/ai/services/ai/ai.service.ts
@@ -4,6 +4,7 @@ import {HttpClient} from '@angular/common/http';
 import {Router} from '@angular/router';
 /* Vendor Dependencies */
 import {Observable, catchError, Subject, BehaviorSubject, of, map, tap, throwError, shareReplay, finalize} from 'rxjs';
+import {v4 as uuidv4} from 'uuid';
 /* Application Dependencies */
 import {CacheService} from '@client/modules/cache/services/cache/cache.service';
 import {ApiService} from '@client/modules/api/services/api/api.service';
@@ -139,7 +140,7 @@ export class AiService {
 	}
 
 	public openAiSocket(assistant: AiAssistant, content: string | null, context?: string): void {
-		const subscription_id = crypto.randomUUID();
+		const subscription_id = uuidv4();
 		const ai_model = this.settingDeviceService.getModel();
 		this.subscription_id = subscription_id;
 		this.active_subject.next(true);

--- a/src/client/modules/bitcoin/services/bitcoin/bitcoin.service.ts
+++ b/src/client/modules/bitcoin/services/bitcoin/bitcoin.service.ts
@@ -4,6 +4,7 @@ import {HttpClient} from '@angular/common/http';
 import {Router} from '@angular/router';
 /* Vendor Dependencies */
 import {BehaviorSubject, catchError, map, Observable, of, shareReplay, tap, throwError, Subject, finalize} from 'rxjs';
+import {v4 as uuidv4} from 'uuid';
 /* Application Dependencies */
 import {getApiQuery, hasGqlWsErrorCode} from '@client/modules/api/helpers/api.helpers';
 import {OrchardErrors} from '@client/modules/error/classes/error.class';
@@ -364,7 +365,7 @@ export class BitcoinService {
 	 * @param {number} end_date - Unix timestamp for end date
 	 */
 	public openBackfillSocket(start_date: number, end_date?: number | null): void {
-		const subscription_id = crypto.randomUUID();
+		const subscription_id = uuidv4();
 		this.backfill_subscription_id = subscription_id;
 		this.backfill_active_subject.next(true);
 

--- a/src/client/modules/event/classes/event-data.class.spec.ts
+++ b/src/client/modules/event/classes/event-data.class.spec.ts
@@ -1,0 +1,16 @@
+/* Local Dependencies */
+import {EventData} from './event-data.class';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('EventData', () => {
+	it('assigns a v4 uuid as id (works in non-secure-context browsers, unlike crypto.randomUUID)', () => {
+		const event = new EventData({type: 'PENDING'});
+		expect(event.id).toMatch(UUID_V4_REGEX);
+	});
+
+	it('produces a unique id per instance', () => {
+		const ids = new Set(Array.from({length: 100}, () => new EventData({type: 'PENDING'}).id));
+		expect(ids.size).toBe(100);
+	});
+});

--- a/src/client/modules/event/classes/event-data.class.ts
+++ b/src/client/modules/event/classes/event-data.class.ts
@@ -1,3 +1,6 @@
+/* Vendor Dependencies */
+import {v4 as uuidv4} from 'uuid';
+
 interface EventDataSeed {
 	type: 'PENDING' | 'SAVING' | 'SUBSCRIBED' | 'SUCCESS' | 'WARNING' | 'ERROR';
 	message?: string;
@@ -25,7 +28,7 @@ export class EventData {
 
 	constructor(data: EventDataSeed) {
 		this.type = data.type;
-		this.id = crypto.randomUUID();
+		this.id = uuidv4();
 		this.message = data.message;
 		this.created_at = Math.floor(Date.now() / 1000);
 		this.duration = data.duration || DURATION[this.type];

--- a/src/client/modules/mint/classes/mint-swap.class.spec.ts
+++ b/src/client/modules/mint/classes/mint-swap.class.spec.ts
@@ -1,0 +1,28 @@
+/* Local Dependencies */
+import {MintSwap} from './mint-swap.class';
+/* Shared Dependencies */
+import {OrchardMintSwap, MintUnit} from '@shared/generated.types';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const seed = (): OrchardMintSwap =>
+	({
+		operation_id: 'op-1',
+		keyset_ids: ['ks-1'],
+		unit: MintUnit.Sat,
+		amount: 100,
+		created_time: 1777503600,
+		fee: 0,
+	}) as unknown as OrchardMintSwap;
+
+describe('MintSwap', () => {
+	it('assigns a v4 uuid as id (works in non-secure-context browsers, unlike crypto.randomUUID)', () => {
+		const swap = new MintSwap(seed());
+		expect(swap.id).toMatch(UUID_V4_REGEX);
+	});
+
+	it('produces a unique id per instance', () => {
+		const ids = new Set(Array.from({length: 100}, () => new MintSwap(seed()).id));
+		expect(ids.size).toBe(100);
+	});
+});

--- a/src/client/modules/mint/classes/mint-swap.class.ts
+++ b/src/client/modules/mint/classes/mint-swap.class.ts
@@ -1,3 +1,5 @@
+/* Vendor Dependencies */
+import {v4 as uuidv4} from 'uuid';
 /* Shared Dependencies */
 import {OrchardMintSwap, MintUnit} from '@shared/generated.types';
 
@@ -11,7 +13,7 @@ export class MintSwap implements OrchardMintSwap {
 	public fee: number | null;
 
 	constructor(swap: OrchardMintSwap) {
-		this.id = crypto.randomUUID();
+		this.id = uuidv4();
 		this.operation_id = swap.operation_id ?? null;
 		this.keyset_ids = swap.keyset_ids;
 		this.unit = swap.unit;


### PR DESCRIPTION
## Bug Fixes
- **Client UUID generation works over plain HTTP** — `crypto.randomUUID()` requires a secure context, so operators on LAN IPs, `.local`, or `.onion` saw "not a function" failures and broken `EventData` PENDING events. Replaced all five client call sites with `uuid` v4, which uses `crypto.getRandomValues` and has no secure-context restriction.

## Changes
- **Add `uuid@^14` as a runtime dep** — package.json/lock updated; imported as `v4 as uuidv4` in `ai-chat-compiled-message.class`, `ai.service`, `bitcoin.service`, `event-data.class`, and `mint-swap.class`.
