### PR TITLE
chore: site-rebuild release workflow

### DIFF
--- a/.github/workflows/site-rebuilds.yml
+++ b/.github/workflows/site-rebuilds.yml
@@ -1,0 +1,21 @@
+name: Rebuild Sites on Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  rebuild:
+    # Prereleases don't change releases/latest, so skip them
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rebuild marketing site (orchard.space)
+        run: curl -fsS -X POST "${{ secrets.CF_HOOK_ORCHARD_SPACE }}"
+
+      - name: Rebuild docs site (docs.orchard.space)
+        if: ${{ !cancelled() }} # still fires if the first hook errored
+        run: curl -fsS -X POST "${{ secrets.CF_HOOK_ORCHARD_DOCS }}"


### PR DESCRIPTION
## Changes

**Release site rebuilds** — new GitHub Actions workflow fires Cloudflare deploy hooks to rebuild the marketing (orchard.space) and docs (docs.orchard.space) sites when a release is published.