### PR TITLE
feat: date range short dates

### DIFF
--- a/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.html
+++ b/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.html
@@ -6,7 +6,7 @@
 	<div class="picker-panel">
 		<div class="preset-column">
 			<mat-nav-list>
-				@for (option of preset_options; track option.value) {
+				@for (option of preset_options(); track option.value) {
 					<a mat-list-item (click)="onPresetSelected(option.value)" [activated]="active_preset() === option.value">
 						{{ option.label }}
 					</a>

--- a/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.scss
+++ b/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.scss
@@ -26,11 +26,11 @@
 	@extend %orc-corner-large;
 	@extend %orc-level3;
 	@extend %overflow-hidden;
-	width: 440px;
+	width: 465px;
 	height: 400px;
 
 	@media (max-width: 599px) {
-		width: 320px;
+		width: 345px;
 		height: 360px;
 	}
 }
@@ -42,10 +42,10 @@
 	@extend %orc-outline-variant-border;
 	@extend %overflow-y-auto;
 	@extend %p-0-5;
-	width: 140px;
+	width: 165px;
 
 	@media (max-width: 599px) {
-		width: 110px;
+		width: 135px;
 		padding: 0.25rem; // %p-0-25
 		font-size: 0.75rem; // %font-size-xs
 	}

--- a/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.spec.ts
+++ b/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.spec.ts
@@ -6,7 +6,7 @@ import {DateRange} from '@angular/material/datepicker';
 import {DateTime} from 'luxon';
 /* Native Dependencies */
 import {OrcFormModule} from '@client/modules/form/form.module';
-import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+import {DateRangePreset, METRICS_DATE_RANGE_PRESET_OPTIONS} from '@client/modules/form/types/form-daterange.types';
 /* Local Dependencies */
 import {FormDaterangeScrollPickerComponent} from './form-daterange-scroll-picker.component';
 
@@ -42,8 +42,14 @@ describe('FormDaterangeScrollPickerComponent', () => {
 		expect(component.is_open()).toBe(false);
 	});
 
-	it('should have all preset options', () => {
-		expect(component.preset_options.length).toBe(7);
+	it('should default to the day-granularity preset options', () => {
+		expect(component.preset_options().length).toBe(7);
+	});
+
+	it('should use the preset options provided via input', () => {
+		fixture.componentRef.setInput('preset_options', METRICS_DATE_RANGE_PRESET_OPTIONS);
+		fixture.detectChanges();
+		expect(component.preset_options().length).toBe(METRICS_DATE_RANGE_PRESET_OPTIONS.length);
 	});
 
 	it('should compute current_range from date_start and date_end inputs', () => {

--- a/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.ts
+++ b/src/client/modules/form/components/form-daterange-scroll-picker/form-daterange-scroll-picker.component.ts
@@ -35,6 +35,7 @@ export class FormDaterangeScrollPickerComponent implements OnDestroy {
 	public date_start = input<DateTime | null>(null);
 	public date_end = input<DateTime | null>(null);
 	public active_preset = input<string | null>(null);
+	public preset_options = input<DateRangePresetOption[]>(DATE_RANGE_PRESET_OPTIONS);
 	public min = input<DateTime | null>(null);
 	public max = input<DateTime | null>(null);
 	public dateClass = input<MatCalendarCellClassFunction<DateTime>>(() => '');
@@ -49,7 +50,6 @@ export class FormDaterangeScrollPickerComponent implements OnDestroy {
 	public trigger_el = viewChild.required<ElementRef>('triggerButton');
 
 	public is_open = signal(false);
-	public readonly preset_options: DateRangePresetOption[] = DATE_RANGE_PRESET_OPTIONS;
 
 	public current_range = computed(() => {
 		return new DateRange<DateTime>(this.date_start(), this.date_end());

--- a/src/client/modules/form/helpers/form-daterange.helpers.spec.ts
+++ b/src/client/modules/form/helpers/form-daterange.helpers.spec.ts
@@ -1,0 +1,63 @@
+/* Vendor Dependencies */
+import {DateTime} from 'luxon';
+/* Local Dependencies */
+import {getDateRangePresetLabel, isSubDayDateRangePreset, resolveDateRangePreset} from './form-daterange.helpers';
+import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+
+describe('form-daterange.helpers', () => {
+	// Fixed anchor so rolling windows resolve deterministically
+	const now = DateTime.fromISO('2026-07-21T15:30:00', {zone: 'utc'});
+
+	describe('resolveDateRangePreset', () => {
+		it('resolves Last15Minutes to a rolling now-relative window without day snapping', () => {
+			const resolved = resolveDateRangePreset(DateRangePreset.Last15Minutes, 0, now);
+			expect(resolved.date_end).toBe(now.toUnixInteger());
+			expect(resolved.date_start).toBe(now.minus({minutes: 15}).toUnixInteger());
+			expect(resolved.date_end - resolved.date_start).toBe(15 * 60);
+		});
+
+		it('resolves each rolling window to its exact span ending at now', () => {
+			const cases: [DateRangePreset, number][] = [
+				[DateRangePreset.Last5Minutes, 5 * 60],
+				[DateRangePreset.Last30Minutes, 30 * 60],
+				[DateRangePreset.Last1Hour, 60 * 60],
+				[DateRangePreset.Last6Hours, 6 * 60 * 60],
+				[DateRangePreset.Last12Hours, 12 * 60 * 60],
+				[DateRangePreset.Last24Hours, 24 * 60 * 60],
+			];
+			for (const [preset, span] of cases) {
+				const resolved = resolveDateRangePreset(preset, 0, now);
+				expect(resolved.date_end).toBe(now.toUnixInteger());
+				expect(resolved.date_end - resolved.date_start).toBe(span);
+			}
+		});
+
+		it('snaps day-granularity presets to day boundaries', () => {
+			const resolved = resolveDateRangePreset(DateRangePreset.Last2Days, 0, now);
+			expect(resolved.date_end).toBe(Math.floor(now.endOf('day').toSeconds()));
+			expect(resolved.date_start).toBe(Math.floor(now.minus({days: 2}).startOf('day').toSeconds()));
+		});
+	});
+
+	describe('isSubDayDateRangePreset', () => {
+		it('is true for rolling sub-day presets', () => {
+			expect(isSubDayDateRangePreset(DateRangePreset.Last5Minutes)).toBe(true);
+			expect(isSubDayDateRangePreset(DateRangePreset.Last15Minutes)).toBe(true);
+			expect(isSubDayDateRangePreset(DateRangePreset.Last24Hours)).toBe(true);
+		});
+
+		it('is false for day-granularity presets and null', () => {
+			expect(isSubDayDateRangePreset(DateRangePreset.Last2Days)).toBe(false);
+			expect(isSubDayDateRangePreset(DateRangePreset.Last7Days)).toBe(false);
+			expect(isSubDayDateRangePreset(null)).toBe(false);
+			expect(isSubDayDateRangePreset(undefined)).toBe(false);
+		});
+	});
+
+	describe('getDateRangePresetLabel', () => {
+		it('returns the human-readable label for a preset', () => {
+			expect(getDateRangePresetLabel(DateRangePreset.Last5Minutes)).toBe('Last 5 minutes');
+			expect(getDateRangePresetLabel(DateRangePreset.Last1Hour)).toBe('Last 1 hour');
+		});
+	});
+});

--- a/src/client/modules/form/helpers/form-daterange.helpers.spec.ts
+++ b/src/client/modules/form/helpers/form-daterange.helpers.spec.ts
@@ -37,6 +37,12 @@ describe('form-daterange.helpers', () => {
 			expect(resolved.date_end).toBe(Math.floor(now.endOf('day').toSeconds()));
 			expect(resolved.date_start).toBe(Math.floor(now.minus({days: 2}).startOf('day').toSeconds()));
 		});
+
+		it('snaps Last90Days to the retention-window boundary', () => {
+			const resolved = resolveDateRangePreset(DateRangePreset.Last90Days, 0, now);
+			expect(resolved.date_end).toBe(Math.floor(now.endOf('day').toSeconds()));
+			expect(resolved.date_start).toBe(Math.floor(now.minus({days: 90}).startOf('day').toSeconds()));
+		});
 	});
 
 	describe('isSubDayDateRangePreset', () => {
@@ -58,6 +64,11 @@ describe('form-daterange.helpers', () => {
 		it('returns the human-readable label for a preset', () => {
 			expect(getDateRangePresetLabel(DateRangePreset.Last5Minutes)).toBe('Last 5 minutes');
 			expect(getDateRangePresetLabel(DateRangePreset.Last1Hour)).toBe('Last 1 hour');
+		});
+
+		it('returns an empty string for a preset outside the metrics list or null', () => {
+			expect(getDateRangePresetLabel(DateRangePreset.ThisQuarter)).toBe('');
+			expect(getDateRangePresetLabel(null)).toBe('');
 		});
 	});
 });

--- a/src/client/modules/form/helpers/form-daterange.helpers.ts
+++ b/src/client/modules/form/helpers/form-daterange.helpers.ts
@@ -1,7 +1,21 @@
 /* Vendor Dependencies */
 import {DateTime} from 'luxon';
 /* Application Dependencies */
-import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+import {
+	DateRangePreset,
+	METRICS_DATE_RANGE_PRESET_OPTIONS,
+	SUB_DAY_DATE_RANGE_PRESET_OPTIONS,
+} from '@client/modules/form/types/form-daterange.types';
+
+/** True when the preset is a rolling sub-day window (Last 15 minutes, Last hour, etc.) */
+export function isSubDayDateRangePreset(preset: DateRangePreset | null | undefined): boolean {
+	return preset != null && SUB_DAY_DATE_RANGE_PRESET_OPTIONS.some((option) => option.value === preset);
+}
+
+/** Human-readable label for a preset (e.g. 'Last 15 minutes'), or an empty string when unknown */
+export function getDateRangePresetLabel(preset: DateRangePreset | null | undefined): string {
+	return METRICS_DATE_RANGE_PRESET_OPTIONS.find((option) => option.value === preset)?.label ?? '';
+}
 
 /** Resolves a preset to unix-second timestamps for date_start and date_end */
 export function resolveDateRangePreset(
@@ -11,6 +25,22 @@ export function resolveDateRangePreset(
 ): {date_start: number; date_end: number} {
 	const end_of_today = Math.floor(now.endOf('day').toSeconds());
 	switch (preset) {
+		case DateRangePreset.Last5Minutes:
+			return {date_start: now.minus({minutes: 5}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last15Minutes:
+			return {date_start: now.minus({minutes: 15}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last30Minutes:
+			return {date_start: now.minus({minutes: 30}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last1Hour:
+			return {date_start: now.minus({hours: 1}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last6Hours:
+			return {date_start: now.minus({hours: 6}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last12Hours:
+			return {date_start: now.minus({hours: 12}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last24Hours:
+			return {date_start: now.minus({hours: 24}).toUnixInteger(), date_end: now.toUnixInteger()};
+		case DateRangePreset.Last2Days:
+			return {date_start: now.minus({days: 2}).startOf('day').toUnixInteger(), date_end: end_of_today};
 		case DateRangePreset.Last7Days:
 			return {date_start: Math.floor(now.minus({days: 7}).startOf('day').toSeconds()), date_end: end_of_today};
 		case DateRangePreset.Last30Days:

--- a/src/client/modules/form/types/form-daterange.types.ts
+++ b/src/client/modules/form/types/form-daterange.types.ts
@@ -1,4 +1,12 @@
 export enum DateRangePreset {
+	Last5Minutes = 'last_5_minutes',
+	Last15Minutes = 'last_15_minutes',
+	Last30Minutes = 'last_30_minutes',
+	Last1Hour = 'last_1_hour',
+	Last6Hours = 'last_6_hours',
+	Last12Hours = 'last_12_hours',
+	Last24Hours = 'last_24_hours',
+	Last2Days = 'last_2_days',
 	Last7Days = 'last_7_days',
 	Last30Days = 'last_30_days',
 	Last90Days = 'last_90_days',
@@ -13,6 +21,18 @@ export type DateRangePresetOption = {
 	value: DateRangePreset;
 };
 
+/** Rolling sub-day windows — these resolve to now-relative timestamps and never snap to day boundaries */
+export const SUB_DAY_DATE_RANGE_PRESET_OPTIONS: DateRangePresetOption[] = [
+	{label: 'Last 5 minutes', value: DateRangePreset.Last5Minutes},
+	{label: 'Last 15 minutes', value: DateRangePreset.Last15Minutes},
+	{label: 'Last 30 minutes', value: DateRangePreset.Last30Minutes},
+	{label: 'Last 1 hour', value: DateRangePreset.Last1Hour},
+	{label: 'Last 6 hours', value: DateRangePreset.Last6Hours},
+	{label: 'Last 12 hours', value: DateRangePreset.Last12Hours},
+	{label: 'Last 24 hours', value: DateRangePreset.Last24Hours},
+];
+
+/** Default day-granularity presets used by the shared picker's non-metrics consumers */
 export const DATE_RANGE_PRESET_OPTIONS: DateRangePresetOption[] = [
 	{label: 'Last 7 days', value: DateRangePreset.Last7Days},
 	{label: 'Last 30 days', value: DateRangePreset.Last30Days},
@@ -21,4 +41,13 @@ export const DATE_RANGE_PRESET_OPTIONS: DateRangePresetOption[] = [
 	{label: 'This Year', value: DateRangePreset.ThisYear},
 	{label: 'Last Year', value: DateRangePreset.LastYear},
 	{label: 'All Time', value: DateRangePreset.AllTime},
+];
+
+/** Metrics surfaces offer rolling sub-day windows plus day presets, capped at the 90-day retention window */
+export const METRICS_DATE_RANGE_PRESET_OPTIONS: DateRangePresetOption[] = [
+	...SUB_DAY_DATE_RANGE_PRESET_OPTIONS,
+	{label: 'Last 2 days', value: DateRangePreset.Last2Days},
+	{label: 'Last 7 days', value: DateRangePreset.Last7Days},
+	{label: 'Last 30 days', value: DateRangePreset.Last30Days},
+	{label: 'Last 90 days', value: DateRangePreset.Last90Days},
 ];

--- a/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.spec.ts
+++ b/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.spec.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, tick, discardPeriodicTasks} from '@angular/core/testing';
 import {ActivatedRoute} from '@angular/router';
 /* Vendor Dependencies */
 import {of, Subject} from 'rxjs';
@@ -192,6 +192,71 @@ describe('IndexSubsectionSystemComponent', () => {
 		expect(args.date_end - args.date_start).toBe(15 * 60);
 		expect(component.page_settings()?.date_end).toBe(args.date_end);
 	});
+
+	it('should silently auto-advance a rolling minute window every minute', fakeAsync(() => {
+		const system_service = TestBed.inject(SystemService) as unknown as {loadSystemMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(IndexSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const before = Math.floor(Date.now() / 1000);
+		const calls_before = system_service.loadSystemMetrics.calls.count();
+		tick(60000);
+		expect(system_service.loadSystemMetrics.calls.count()).toBe(calls_before + 1);
+		const args = system_service.loadSystemMetrics.calls.mostRecent().args[0];
+		expect(args.date_end).toBeGreaterThanOrEqual(before);
+		expect(args.date_end - args.date_start).toBe(15 * 60);
+		expect(live_fixture.componentInstance.loading_metrics()).toBeFalse();
+		discardPeriodicTasks();
+	}));
+
+	it('should drop a stale auto-refresh response once a manual refresh supersedes it', fakeAsync(() => {
+		const system_service = TestBed.inject(SystemService) as unknown as {loadSystemMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(IndexSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const stale_response = new Subject<SystemMetricSample[]>();
+		system_service.loadSystemMetrics.and.returnValue(stale_response);
+		tick(60000);
+		const fresh = [new SystemMetricSample({metric: SystemMetric.CpuPercent, date: 60, value: 1})];
+		system_service.loadSystemMetrics.and.returnValue(of(fresh));
+		live_fixture.componentInstance.onRefresh();
+		stale_response.next([]);
+		expect(live_fixture.componentInstance.metrics()).toEqual(fresh);
+		discardPeriodicTasks();
+	}));
+
+	it('should not auto-advance without a rolling minute window', fakeAsync(() => {
+		const system_service = TestBed.inject(SystemService) as unknown as {loadSystemMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(IndexSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: null,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const calls_before = system_service.loadSystemMetrics.calls.count();
+		tick(60000);
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last6Hours,
+			interval: SystemMetricsInterval.Hour,
+		});
+		tick(60000);
+		expect(system_service.loadSystemMetrics.calls.count()).toBe(calls_before);
+		discardPeriodicTasks();
+	}));
 
 	it('should route a DATE_RANGE_UPDATE tool call to onDateChange with unix timestamps', () => {
 		const on_date_change = spyOn(component, 'onDateChange');

--- a/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.spec.ts
+++ b/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.spec.ts
@@ -11,6 +11,7 @@ import {SettingDeviceService} from '@client/modules/settings/services/setting-de
 import {SettingAppService} from '@client/modules/settings/services/setting-app/setting-app.service';
 import {AiService} from '@client/modules/ai/services/ai/ai.service';
 import {AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
+import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
 /* Native Dependencies */
 import {OrcIndexSubsectionSystemModule} from '@client/modules/index/modules/index-subsection-system/index-subsection-system.module';
 import {SystemService} from '@client/modules/index/services/system/system.service';
@@ -151,6 +152,45 @@ describe('IndexSubsectionSystemComponent', () => {
 		component.onRefresh();
 		expect(system_service.clearMetricsCache).toHaveBeenCalled();
 		expect(component.refreshing()).toBeFalse();
+	});
+
+	it('should resolve a rolling window and derive the interval on preset change', () => {
+		component.onPresetChange(DateRangePreset.Last5Minutes);
+		const settings = component.page_settings();
+		expect(settings?.date_preset).toBe(DateRangePreset.Last5Minutes);
+		expect(settings?.interval).toBe(SystemMetricsInterval.Minute);
+		expect((settings?.date_end ?? 0) - (settings?.date_start ?? 0)).toBe(5 * 60);
+	});
+
+	it('should re-resolve a rolling preset window on interval change', () => {
+		const before = Math.floor(Date.now() / 1000);
+		component.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		component.onIntervalChange(SystemMetricsInterval.Hour);
+		const settings = component.page_settings();
+		expect(settings?.interval).toBe(SystemMetricsInterval.Hour);
+		expect(settings?.date_end).toBeGreaterThanOrEqual(before);
+		expect((settings?.date_end ?? 0) - (settings?.date_start ?? 0)).toBe(15 * 60);
+	});
+
+	it('should slide a rolling preset window forward on refresh', () => {
+		const system_service = TestBed.inject(SystemService) as unknown as {loadSystemMetrics: jasmine.Spy};
+		const before = Math.floor(Date.now() / 1000);
+		component.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		component.onRefresh();
+		const args = system_service.loadSystemMetrics.calls.mostRecent().args[0];
+		expect(args.date_end).toBeGreaterThanOrEqual(before);
+		expect(args.date_end - args.date_start).toBe(15 * 60);
+		expect(component.page_settings()?.date_end).toBe(args.date_end);
 	});
 
 	it('should route a DATE_RANGE_UPDATE tool call to onDateChange with unix timestamps', () => {

--- a/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.ts
+++ b/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.ts
@@ -2,7 +2,7 @@
 import {ChangeDetectionStrategy, Component, OnInit, OnDestroy, computed, inject, signal} from '@angular/core';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 /* Vendor Dependencies */
-import {Subscription} from 'rxjs';
+import {Subscription, timer} from 'rxjs';
 /* Application Dependencies */
 import {SettingDeviceService} from '@client/modules/settings/services/setting-device/setting-device.service';
 import {SettingAppService} from '@client/modules/settings/services/setting-app/setting-app.service';
@@ -17,6 +17,7 @@ import {
 	resolveMetricsDateRangePreset,
 	suggestMetricsInterval,
 	refreshMetricsRange,
+	shouldAutoRefreshMetrics,
 } from '@client/modules/system/helpers/system-settings.helpers';
 import {buildSystemAssistantContext, parseAssistantDateRange} from '@client/modules/system/helpers/system-assistant.helpers';
 import {SystemChartReferenceLine} from '@client/modules/system/types/system.types';
@@ -129,11 +130,13 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 	});
 
 	private subscriptions = new Subscription();
+	private auto_refresh_subscription: Subscription | null = null;
 
 	ngOnInit(): void {
 		this.locale = this.settingDeviceService.getLocale();
 		this.page_settings.set(this.getPageSettings());
 		this.subscriptions.add(this.getBreakpointSubscription());
+		this.subscriptions.add(this.getAutoRefreshSubscription());
 		this.orchardOptionalInit();
 		this.loadInfo();
 		this.loadMetrics();
@@ -172,6 +175,11 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 			.subscribe((result) => this.device_type.set(deviceTypeFromBreakpoints(result)));
 	}
 
+	/** Ticks every minute; each tick decides whether a live minute window is active */
+	private getAutoRefreshSubscription(): Subscription {
+		return timer(60000, 60000).subscribe(() => this.autoRefreshMetrics());
+	}
+
 	/* *******************************************************
 		Data
 	******************************************************** */
@@ -196,6 +204,7 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 	private loadMetrics(): void {
 		const settings = this.page_settings();
 		if (!settings) return;
+		this.auto_refresh_subscription?.unsubscribe();
 		this.loading_metrics.set(true);
 		this.subscriptions.add(
 			this.systemService
@@ -234,10 +243,34 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 		return series.reduce((latest, m) => (m.date > latest.date ? m : latest)).value;
 	}
 
+	/** Rolls the window forward and silently refetches without touching loading state */
+	private autoRefreshMetrics(): void {
+		const settings = this.page_settings();
+		if (!shouldAutoRefreshMetrics(settings) || this.loading_metrics() || this.refreshing() || document.hidden) return;
+		const refreshed_settings = refreshMetricsRange(settings!);
+		this.page_settings.set(refreshed_settings);
+		this.settingDeviceService.setSystemMetricsSettings(refreshed_settings);
+		this.auto_refresh_subscription?.unsubscribe();
+		this.auto_refresh_subscription = this.systemService
+			.loadSystemMetrics({
+				date_start: refreshed_settings.date_start,
+				date_end: refreshed_settings.date_end,
+				interval: refreshed_settings.interval,
+				timezone: this.settingDeviceService.getTimezone(),
+				metrics: SYSTEM_METRIC_FAMILIES,
+			})
+			.subscribe({
+				next: (metrics: SystemMetricSample[]) => this.metrics.set(metrics),
+				// silent tick: keep the last data and let the timer retry next minute
+				error: () => {},
+			});
+	}
+
 	/** Forces a fresh fetch of the stored series against a re-resolved rolling window, then pulses the page */
 	public onRefresh(): void {
 		const settings = this.page_settings();
 		if (!settings || this.refreshing()) return;
+		this.auto_refresh_subscription?.unsubscribe();
 		const refreshed_settings = refreshMetricsRange(settings);
 		this.page_settings.set(refreshed_settings);
 		this.settingDeviceService.setSystemMetricsSettings(refreshed_settings);
@@ -331,6 +364,7 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 	******************************************************** */
 
 	ngOnDestroy(): void {
+		this.auto_refresh_subscription?.unsubscribe();
 		this.subscriptions.unsubscribe();
 	}
 }

--- a/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.ts
+++ b/src/client/modules/index/modules/index-subsection-system/components/index-subsection-system/index-subsection-system.component.ts
@@ -10,10 +10,14 @@ import {AiService} from '@client/modules/ai/services/ai/ai.service';
 import {AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
 import {NonNullableSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
 import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
-import {resolveDateRangePreset} from '@client/modules/form/helpers/form-daterange.helpers';
 import {DeviceType} from '@client/modules/layout/types/device.types';
 import {deviceTypeFromBreakpoints} from '@client/modules/layout/helpers/device.helpers';
-import {resolveSystemMetricsSettings, getMetricsGenesisTime} from '@client/modules/system/helpers/system-settings.helpers';
+import {
+	resolveSystemMetricsSettings,
+	resolveMetricsDateRangePreset,
+	suggestMetricsInterval,
+	refreshMetricsRange,
+} from '@client/modules/system/helpers/system-settings.helpers';
 import {buildSystemAssistantContext, parseAssistantDateRange} from '@client/modules/system/helpers/system-assistant.helpers';
 import {SystemChartReferenceLine} from '@client/modules/system/types/system.types';
 /* Native Dependencies */
@@ -230,19 +234,22 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 		return series.reduce((latest, m) => (m.date > latest.date ? m : latest)).value;
 	}
 
-	/** Forces a fresh fetch of the stored series, then pulses the page */
+	/** Forces a fresh fetch of the stored series against a re-resolved rolling window, then pulses the page */
 	public onRefresh(): void {
 		const settings = this.page_settings();
 		if (!settings || this.refreshing()) return;
+		const refreshed_settings = refreshMetricsRange(settings);
+		this.page_settings.set(refreshed_settings);
+		this.settingDeviceService.setSystemMetricsSettings(refreshed_settings);
 		this.refreshing.set(true);
 		this.loading_metrics.set(true);
 		this.systemService.clearMetricsCache();
 		this.subscriptions.add(
 			this.systemService
 				.loadSystemMetrics({
-					date_start: settings.date_start,
-					date_end: settings.date_end,
-					interval: settings.interval,
+					date_start: refreshed_settings.date_start,
+					date_end: refreshed_settings.date_end,
+					interval: refreshed_settings.interval,
 					timezone: this.settingDeviceService.getTimezone(),
 					metrics: SYSTEM_METRIC_FAMILIES,
 				})
@@ -302,14 +309,21 @@ export class IndexSubsectionSystemComponent implements OnInit, OnDestroy {
 	public onPresetChange(preset: DateRangePreset): void {
 		const settings = this.page_settings();
 		if (!settings) return;
-		const resolved_dates = resolveDateRangePreset(preset, getMetricsGenesisTime());
-		this.updateSettings({...settings, date_start: resolved_dates.date_start, date_end: resolved_dates.date_end, date_preset: preset});
+		const resolved_dates = resolveMetricsDateRangePreset(preset);
+		const interval = suggestMetricsInterval(preset) ?? settings.interval;
+		this.updateSettings({
+			...settings,
+			date_start: resolved_dates.date_start,
+			date_end: resolved_dates.date_end,
+			date_preset: preset,
+			interval,
+		});
 	}
 
 	public onIntervalChange(interval: SystemMetricsInterval): void {
 		const settings = this.page_settings();
 		if (!settings) return;
-		this.updateSettings({...settings, interval});
+		this.updateSettings(refreshMetricsRange({...settings, interval}));
 	}
 
 	/* *******************************************************

--- a/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.spec.ts
+++ b/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.spec.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed, fakeAsync, tick, discardPeriodicTasks} from '@angular/core/testing';
 import {ActivatedRoute} from '@angular/router';
 /* Vendor Dependencies */
 import {of, Subject} from 'rxjs';
@@ -13,6 +13,7 @@ import {SettingAppService} from '@client/modules/settings/services/setting-app/s
 import {AiService} from '@client/modules/ai/services/ai/ai.service';
 import {AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
 import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+import {MintMetric} from '@client/modules/mint/classes/mint-metric.class';
 /* Native Dependencies */
 import {OrcMintSubsectionSystemModule} from '@client/modules/mint/modules/mint-subsection-system/mint-subsection-system.module';
 /* Local Dependencies */
@@ -155,6 +156,71 @@ describe('MintSubsectionSystemComponent', () => {
 		expect(args.date_end - args.date_start).toBe(15 * 60);
 		expect(component.page_settings()?.date_end).toBe(args.date_end);
 	});
+
+	it('should silently auto-advance a rolling minute window every minute', fakeAsync(() => {
+		const mint_service = TestBed.inject(MintService) as unknown as {loadMintMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(MintSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const before = Math.floor(Date.now() / 1000);
+		const calls_before = mint_service.loadMintMetrics.calls.count();
+		tick(60000);
+		expect(mint_service.loadMintMetrics.calls.count()).toBe(calls_before + 1);
+		const args = mint_service.loadMintMetrics.calls.mostRecent().args[0];
+		expect(args.date_end).toBeGreaterThanOrEqual(before);
+		expect(args.date_end - args.date_start).toBe(15 * 60);
+		expect(live_fixture.componentInstance.loading_metrics()).toBeFalse();
+		discardPeriodicTasks();
+	}));
+
+	it('should drop a stale auto-refresh response once a manual refresh supersedes it', fakeAsync(() => {
+		const mint_service = TestBed.inject(MintService) as unknown as {loadMintMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(MintSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const stale_response = new Subject<MintMetric[]>();
+		mint_service.loadMintMetrics.and.returnValue(stale_response);
+		tick(60000);
+		const fresh = [{metric: 'cdk_mint_operations_total', date: 60, value: 1}] as unknown as MintMetric[];
+		mint_service.loadMintMetrics.and.returnValue(of(fresh));
+		live_fixture.componentInstance.onRefresh();
+		stale_response.next([]);
+		expect(live_fixture.componentInstance.metrics()).toEqual(fresh);
+		discardPeriodicTasks();
+	}));
+
+	it('should not auto-advance without a rolling minute window', fakeAsync(() => {
+		const mint_service = TestBed.inject(MintService) as unknown as {loadMintMetrics: jasmine.Spy};
+		const live_fixture = TestBed.createComponent(MintSubsectionSystemComponent);
+		live_fixture.detectChanges();
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: null,
+			interval: SystemMetricsInterval.Minute,
+		});
+		const calls_before = mint_service.loadMintMetrics.calls.count();
+		tick(60000);
+		live_fixture.componentInstance.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last6Hours,
+			interval: SystemMetricsInterval.Hour,
+		});
+		tick(60000);
+		expect(mint_service.loadMintMetrics.calls.count()).toBe(calls_before);
+		discardPeriodicTasks();
+	}));
 
 	it('should route a DATE_RANGE_UPDATE tool call to onDateChange with unix timestamps', () => {
 		const on_date_change = spyOn(component, 'onDateChange');

--- a/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.spec.ts
+++ b/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.spec.ts
@@ -12,6 +12,7 @@ import {SettingDeviceService} from '@client/modules/settings/services/setting-de
 import {SettingAppService} from '@client/modules/settings/services/setting-app/setting-app.service';
 import {AiService} from '@client/modules/ai/services/ai/ai.service';
 import {AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
+import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
 /* Native Dependencies */
 import {OrcMintSubsectionSystemModule} from '@client/modules/mint/modules/mint-subsection-system/mint-subsection-system.module';
 /* Local Dependencies */
@@ -114,6 +115,45 @@ describe('MintSubsectionSystemComponent', () => {
 		component.onRefresh();
 		expect(mint_service.clearMetricsCache).toHaveBeenCalled();
 		expect(component.refreshing()).toBeFalse();
+	});
+
+	it('should resolve a rolling window and derive the interval on preset change', () => {
+		component.onPresetChange(DateRangePreset.Last5Minutes);
+		const settings = component.page_settings();
+		expect(settings?.date_preset).toBe(DateRangePreset.Last5Minutes);
+		expect(settings?.interval).toBe(SystemMetricsInterval.Minute);
+		expect((settings?.date_end ?? 0) - (settings?.date_start ?? 0)).toBe(5 * 60);
+	});
+
+	it('should re-resolve a rolling preset window on interval change', () => {
+		const before = Math.floor(Date.now() / 1000);
+		component.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		component.onIntervalChange(SystemMetricsInterval.Hour);
+		const settings = component.page_settings();
+		expect(settings?.interval).toBe(SystemMetricsInterval.Hour);
+		expect(settings?.date_end).toBeGreaterThanOrEqual(before);
+		expect((settings?.date_end ?? 0) - (settings?.date_start ?? 0)).toBe(15 * 60);
+	});
+
+	it('should slide a rolling preset window forward on refresh', () => {
+		const mint_service = TestBed.inject(MintService) as unknown as {loadMintMetrics: jasmine.Spy};
+		const before = Math.floor(Date.now() / 1000);
+		component.page_settings.set({
+			date_start: 0,
+			date_end: 900,
+			date_preset: DateRangePreset.Last15Minutes,
+			interval: SystemMetricsInterval.Minute,
+		});
+		component.onRefresh();
+		const args = mint_service.loadMintMetrics.calls.mostRecent().args[0];
+		expect(args.date_end).toBeGreaterThanOrEqual(before);
+		expect(args.date_end - args.date_start).toBe(15 * 60);
+		expect(component.page_settings()?.date_end).toBe(args.date_end);
 	});
 
 	it('should route a DATE_RANGE_UPDATE tool call to onDateChange with unix timestamps', () => {

--- a/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.ts
@@ -3,7 +3,7 @@ import {ChangeDetectionStrategy, Component, OnInit, OnDestroy, computed, inject,
 import {ActivatedRoute} from '@angular/router';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 /* Vendor Dependencies */
-import {Subscription} from 'rxjs';
+import {Subscription, timer} from 'rxjs';
 /* Application Dependencies */
 import {MintService} from '@client/modules/mint/services/mint/mint.service';
 import {SettingDeviceService} from '@client/modules/settings/services/setting-device/setting-device.service';
@@ -19,6 +19,7 @@ import {
 	resolveMetricsDateRangePreset,
 	suggestMetricsInterval,
 	refreshMetricsRange,
+	shouldAutoRefreshMetrics,
 } from '@client/modules/system/helpers/system-settings.helpers';
 import {buildSystemAssistantContext, parseAssistantDateRange} from '@client/modules/system/helpers/system-assistant.helpers';
 /* Native Dependencies */
@@ -94,12 +95,14 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 	public readonly http_distribution = computed(() => computeEndpointDistribution(this.http_requests_metrics()));
 
 	private subscriptions = new Subscription();
+	private auto_refresh_subscription: Subscription | null = null;
 
 	ngOnInit(): void {
 		this.locale = this.settingDeviceService.getLocale();
 		this.page_settings.set(this.getPageSettings());
 		this.auth_supported.set(this.resolveAuthSupported());
 		this.subscriptions.add(this.getBreakpointSubscription());
+		this.subscriptions.add(this.getAutoRefreshSubscription());
 		this.orchardOptionalInit();
 		this.loadMetrics();
 	}
@@ -143,6 +146,11 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 			.subscribe((result) => this.device_type.set(deviceTypeFromBreakpoints(result)));
 	}
 
+	/** Ticks every minute; each tick decides whether a live minute window is active */
+	private getAutoRefreshSubscription(): Subscription {
+		return timer(60000, 60000).subscribe(() => this.autoRefreshMetrics());
+	}
+
 	/* *******************************************************
 		Data
 	******************************************************** */
@@ -151,6 +159,7 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 	private loadMetrics(): void {
 		const settings = this.page_settings();
 		if (!settings) return;
+		this.auto_refresh_subscription?.unsubscribe();
 		this.loading_metrics.set(true);
 		this.subscriptions.add(
 			this.mintService
@@ -183,10 +192,34 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 		return this.auth_supported() ? [...CHART_METRIC_FAMILIES, ...AUTH_METRIC_FAMILIES] : CHART_METRIC_FAMILIES;
 	}
 
+	/** Rolls the window forward and silently refetches without touching loading state */
+	private autoRefreshMetrics(): void {
+		const settings = this.page_settings();
+		if (!shouldAutoRefreshMetrics(settings) || this.loading_metrics() || this.refreshing() || document.hidden) return;
+		const refreshed_settings = refreshMetricsRange(settings!);
+		this.page_settings.set(refreshed_settings);
+		this.settingDeviceService.setMintSystemSettings(refreshed_settings);
+		this.auto_refresh_subscription?.unsubscribe();
+		this.auto_refresh_subscription = this.mintService
+			.loadMintMetrics({
+				date_start: refreshed_settings.date_start,
+				date_end: refreshed_settings.date_end,
+				interval: refreshed_settings.interval,
+				timezone: this.settingDeviceService.getTimezone(),
+				metrics: this.getMetricFamilies(),
+			})
+			.subscribe({
+				next: (metrics: MintMetric[]) => this.metrics.set(metrics),
+				// silent tick: keep the last data and let the timer retry next minute
+				error: () => {},
+			});
+	}
+
 	/** Forces a fresh fetch of the stored series against a re-resolved rolling window, then pulses the page */
 	public onRefresh(): void {
 		const settings = this.page_settings();
 		if (!settings || this.refreshing()) return;
+		this.auto_refresh_subscription?.unsubscribe();
 		const refreshed_settings = refreshMetricsRange(settings);
 		this.page_settings.set(refreshed_settings);
 		this.settingDeviceService.setMintSystemSettings(refreshed_settings);
@@ -280,6 +313,7 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 	******************************************************** */
 
 	ngOnDestroy(): void {
+		this.auto_refresh_subscription?.unsubscribe();
 		this.subscriptions.unsubscribe();
 	}
 }

--- a/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-system/components/mint-subsection-system/mint-subsection-system.component.ts
@@ -12,10 +12,14 @@ import {AiService} from '@client/modules/ai/services/ai/ai.service';
 import {AiChatToolCall} from '@client/modules/ai/classes/ai-chat-chunk.class';
 import {NonNullableSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
 import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
-import {resolveDateRangePreset} from '@client/modules/form/helpers/form-daterange.helpers';
 import {DeviceType} from '@client/modules/layout/types/device.types';
 import {deviceTypeFromBreakpoints} from '@client/modules/layout/helpers/device.helpers';
-import {resolveSystemMetricsSettings, getMetricsGenesisTime} from '@client/modules/system/helpers/system-settings.helpers';
+import {
+	resolveSystemMetricsSettings,
+	resolveMetricsDateRangePreset,
+	suggestMetricsInterval,
+	refreshMetricsRange,
+} from '@client/modules/system/helpers/system-settings.helpers';
 import {buildSystemAssistantContext, parseAssistantDateRange} from '@client/modules/system/helpers/system-assistant.helpers';
 /* Native Dependencies */
 import {MintInfo} from '@client/modules/mint/classes/mint-info.class';
@@ -179,19 +183,22 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 		return this.auth_supported() ? [...CHART_METRIC_FAMILIES, ...AUTH_METRIC_FAMILIES] : CHART_METRIC_FAMILIES;
 	}
 
-	/** Forces a fresh fetch of the stored series, then pulses the page */
+	/** Forces a fresh fetch of the stored series against a re-resolved rolling window, then pulses the page */
 	public onRefresh(): void {
 		const settings = this.page_settings();
 		if (!settings || this.refreshing()) return;
+		const refreshed_settings = refreshMetricsRange(settings);
+		this.page_settings.set(refreshed_settings);
+		this.settingDeviceService.setMintSystemSettings(refreshed_settings);
 		this.refreshing.set(true);
 		this.loading_metrics.set(true);
 		this.mintService.clearMetricsCache();
 		this.subscriptions.add(
 			this.mintService
 				.loadMintMetrics({
-					date_start: settings.date_start,
-					date_end: settings.date_end,
-					interval: settings.interval,
+					date_start: refreshed_settings.date_start,
+					date_end: refreshed_settings.date_end,
+					interval: refreshed_settings.interval,
 					timezone: this.settingDeviceService.getTimezone(),
 					metrics: this.getMetricFamilies(),
 				})
@@ -251,14 +258,21 @@ export class MintSubsectionSystemComponent implements OnInit, OnDestroy {
 	public onPresetChange(preset: DateRangePreset): void {
 		const settings = this.page_settings();
 		if (!settings) return;
-		const resolved_dates = resolveDateRangePreset(preset, getMetricsGenesisTime());
-		this.updateSettings({...settings, date_start: resolved_dates.date_start, date_end: resolved_dates.date_end, date_preset: preset});
+		const resolved_dates = resolveMetricsDateRangePreset(preset);
+		const interval = suggestMetricsInterval(preset) ?? settings.interval;
+		this.updateSettings({
+			...settings,
+			date_start: resolved_dates.date_start,
+			date_end: resolved_dates.date_end,
+			date_preset: preset,
+			interval,
+		});
 	}
 
 	public onIntervalChange(interval: SystemMetricsInterval): void {
 		const settings = this.page_settings();
 		if (!settings) return;
-		this.updateSettings({...settings, interval});
+		this.updateSettings(refreshMetricsRange({...settings, interval}));
 	}
 
 	/* *******************************************************

--- a/src/client/modules/system/components/system-chart/system-chart.component.spec.ts
+++ b/src/client/modules/system/components/system-chart/system-chart.component.spec.ts
@@ -71,6 +71,38 @@ describe('SystemChartComponent', () => {
 		expect(component.chart_data.datasets.map((dataset) => dataset.label)).toEqual(['CPU']);
 	});
 
+	it('updates dataset data in place on a metrics-only change with the same series', () => {
+		const metrics: SystemChartPoint[] = [{metric: 'cpu_percent', date: 3600, value: 42}];
+		fixture.componentRef.setInput('type', 'line');
+		fixture.componentRef.setInput('unit', 'percent');
+		fixture.componentRef.setInput('metrics', metrics);
+		fixture.componentRef.setInput('loading', false);
+		fixture.detectChanges();
+		const previous_data = component.chart_data;
+
+		fixture.componentRef.setInput('metrics', [...metrics, {metric: 'cpu_percent', date: 3660, value: 43}]);
+		fixture.detectChanges();
+
+		expect(component.chart_data).toBe(previous_data);
+		expect(component.chart_data.datasets[0].data.length).toBe(2);
+	});
+
+	it('fully rebuilds when a metrics-only change introduces a new series', () => {
+		const metrics: SystemChartPoint[] = [{metric: 'cpu_percent', date: 3600, value: 42}];
+		fixture.componentRef.setInput('type', 'line');
+		fixture.componentRef.setInput('unit', 'percent');
+		fixture.componentRef.setInput('metrics', metrics);
+		fixture.componentRef.setInput('loading', false);
+		fixture.detectChanges();
+		const previous_data = component.chart_data;
+
+		fixture.componentRef.setInput('metrics', [...metrics, {metric: 'process_cpu_percent', date: 3600, value: 10}]);
+		fixture.detectChanges();
+
+		expect(component.chart_data).not.toBe(previous_data);
+		expect(component.chart_data.datasets.length).toBe(2);
+	});
+
 	it('adds a y-axis annotation when reference_line is set', () => {
 		const metrics: SystemChartPoint[] = [{metric: 'load_avg_1m', date: 3600, value: 0.5}];
 		fixture.componentRef.setInput('type', 'line');

--- a/src/client/modules/system/components/system-chart/system-chart.component.ts
+++ b/src/client/modules/system/components/system-chart/system-chart.component.ts
@@ -65,6 +65,8 @@ export class SystemChartComponent implements OnChanges, OnDestroy {
 		this.percentiles() ? 'matrix' : this.legend_layout(),
 	);
 
+	private built_series_keys = '';
+
 	private subscriptions: Subscription = new Subscription();
 
 	constructor() {
@@ -74,7 +76,11 @@ export class SystemChartComponent implements OnChanges, OnDestroy {
 
 	ngOnChanges(changes: SimpleChanges): void {
 		if (changes['loading'] && this.loading() === false) this.init();
-		if (changes['metrics'] && !changes['metrics'].firstChange) this.init();
+		if (changes['metrics'] && !changes['metrics'].firstChange) {
+			const metrics_only = Object.keys(changes).length === 1;
+			if (metrics_only && this.getMetricsSeriesKeys() === this.built_series_keys) this.quietUpdate();
+			else this.init();
+		}
 		// Reference values arrive async from system_info, after the series has rendered
 		if (
 			(changes['reference_line'] && !changes['reference_line'].firstChange) ||
@@ -101,15 +107,35 @@ export class SystemChartComponent implements OnChanges, OnDestroy {
 		}, 50);
 	}
 
+	/** Replaces dataset data in place and redraws without animation (live tick) */
+	private quietUpdate(): void {
+		const chart = this.chart()?.chart;
+		const next_data = this.getChartData();
+		if (!chart || next_data.datasets.length !== this.chart_data.datasets.length) return this.init();
+		next_data.datasets.forEach((dataset, index) => (this.chart_data.datasets[index].data = dataset.data));
+		chart.update('none');
+	}
+
+	/** Stable identity for a metric series: family name plus its prometheus label set */
+	private getSeriesKey(metric: SystemChartPoint): string {
+		return `${metric.metric}|${(metric.labels ?? []).map((label) => `${label.name}=${label.value}`).join(',')}`;
+	}
+
+	/** Ordered unique series keys of the current metrics input */
+	private getMetricsSeriesKeys(): string {
+		return Array.from(new Set(this.metrics().map((metric) => this.getSeriesKey(metric)))).join(';');
+	}
+
 	/** Groups metrics by label set into one themed dataset per series */
 	private getChartData(): ChartConfiguration['data'] {
 		const series_map = new Map<string, SystemChartPoint[]>();
 		for (const metric of this.metrics()) {
-			const key = `${metric.metric}|${(metric.labels ?? []).map((label) => `${label.name}=${label.value}`).join(',')}`;
+			const key = this.getSeriesKey(metric);
 			const series = series_map.get(key);
 			if (series) series.push(metric);
 			else series_map.set(key, [metric]);
 		}
+		this.built_series_keys = Array.from(series_map.keys()).join(';');
 
 		if (this.percentiles()) return {datasets: this.getPercentileDatasets(series_map)};
 

--- a/src/client/modules/system/components/system-control/system-control.component.html
+++ b/src/client/modules/system/components/system-control/system-control.component.html
@@ -3,37 +3,56 @@
 		<div class="flex flex-col flex-gap-1">
 			@if (device_type() !== 'mobile') {
 				<div formGroupName="daterange">
-					<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="big-form-field">
-						<mat-label>Date range</mat-label>
-						<mat-date-range-input [rangePicker]="picker">
-							<input
-								matStartDate
-								formControlName="date_start"
-								placeholder="Start date"
-								(blur)="onDateChange()"
-								(keyup.enter)="onDateChange()"
-							/>
-							<input
-								matEndDate
-								formControlName="date_end"
-								placeholder="End date"
-								(blur)="onDateChange()"
-								(keyup.enter)="onDateChange()"
-							/>
-						</mat-date-range-input>
-						<orc-form-daterange-scroll-picker
-							matIconSuffix
-							[date_start]="panel.controls.daterange.controls.date_start.value"
-							[date_end]="panel.controls.daterange.controls.date_end.value"
-							[active_preset]="page_settings().date_preset"
-							[device_type]="device_type()"
-							(presetChange)="onPresetChange($event)"
-							(dateRangeChange)="onDateRangeChange($event)"
-							(closed)="onDateChange()"
-						></orc-form-daterange-scroll-picker>
-						<mat-date-range-picker #picker></mat-date-range-picker>
-						<mat-error class="font-size-xs">Invalid date range</mat-error>
-					</mat-form-field>
+					@if (is_sub_day_window()) {
+						<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="big-form-field">
+							<mat-label>Date range</mat-label>
+							<input matInput readonly [value]="sub_day_label()" />
+							<orc-form-daterange-scroll-picker
+								matIconSuffix
+								[preset_options]="preset_options"
+								[date_start]="panel.controls.daterange.controls.date_start.value"
+								[date_end]="panel.controls.daterange.controls.date_end.value"
+								[active_preset]="page_settings().date_preset"
+								[device_type]="device_type()"
+								(presetChange)="onPresetChange($event)"
+								(dateRangeChange)="onDateRangeChange($event)"
+								(closed)="onDateChange()"
+							></orc-form-daterange-scroll-picker>
+						</mat-form-field>
+					} @else {
+						<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="big-form-field">
+							<mat-label>Date range</mat-label>
+							<mat-date-range-input [rangePicker]="picker">
+								<input
+									matStartDate
+									formControlName="date_start"
+									placeholder="Start date"
+									(blur)="onDateChange()"
+									(keyup.enter)="onDateChange()"
+								/>
+								<input
+									matEndDate
+									formControlName="date_end"
+									placeholder="End date"
+									(blur)="onDateChange()"
+									(keyup.enter)="onDateChange()"
+								/>
+							</mat-date-range-input>
+							<orc-form-daterange-scroll-picker
+								matIconSuffix
+								[preset_options]="preset_options"
+								[date_start]="panel.controls.daterange.controls.date_start.value"
+								[date_end]="panel.controls.daterange.controls.date_end.value"
+								[active_preset]="page_settings().date_preset"
+								[device_type]="device_type()"
+								(presetChange)="onPresetChange($event)"
+								(dateRangeChange)="onDateRangeChange($event)"
+								(closed)="onDateChange()"
+							></orc-form-daterange-scroll-picker>
+							<mat-date-range-picker #picker></mat-date-range-picker>
+							<mat-error class="font-size-xs">Invalid date range</mat-error>
+						</mat-form-field>
+					}
 				</div>
 				<div>
 					<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic">
@@ -64,37 +83,56 @@
 		@if (device_type() === 'mobile') {
 			<form [formGroup]="panel">
 				<div formGroupName="daterange" class="p-1">
-					<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="w-full">
-						<mat-label>Date range</mat-label>
-						<mat-date-range-input [rangePicker]="mobile_picker">
-							<input
-								matStartDate
-								formControlName="date_start"
-								placeholder="Start date"
-								(blur)="onDateChange()"
-								(keyup.enter)="onDateChange()"
-							/>
-							<input
-								matEndDate
-								formControlName="date_end"
-								placeholder="End date"
-								(blur)="onDateChange()"
-								(keyup.enter)="onDateChange()"
-							/>
-						</mat-date-range-input>
-						<orc-form-daterange-scroll-picker
-							matIconSuffix
-							[date_start]="panel.controls.daterange.controls.date_start.value"
-							[date_end]="panel.controls.daterange.controls.date_end.value"
-							[active_preset]="page_settings().date_preset"
-							[device_type]="device_type()"
-							(presetChange)="onPresetChange($event)"
-							(dateRangeChange)="onDateRangeChange($event)"
-							(closed)="onDateChange()"
-						></orc-form-daterange-scroll-picker>
-						<mat-date-range-picker #mobile_picker></mat-date-range-picker>
-						<mat-error class="font-size-xs">Invalid date range</mat-error>
-					</mat-form-field>
+					@if (is_sub_day_window()) {
+						<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="w-full">
+							<mat-label>Date range</mat-label>
+							<input matInput readonly [value]="sub_day_label()" />
+							<orc-form-daterange-scroll-picker
+								matIconSuffix
+								[preset_options]="preset_options"
+								[date_start]="panel.controls.daterange.controls.date_start.value"
+								[date_end]="panel.controls.daterange.controls.date_end.value"
+								[active_preset]="page_settings().date_preset"
+								[device_type]="device_type()"
+								(presetChange)="onPresetChange($event)"
+								(dateRangeChange)="onDateRangeChange($event)"
+								(closed)="onDateChange()"
+							></orc-form-daterange-scroll-picker>
+						</mat-form-field>
+					} @else {
+						<mat-form-field hideRequiredMarker="true" subscriptSizing="dynamic" class="w-full">
+							<mat-label>Date range</mat-label>
+							<mat-date-range-input [rangePicker]="mobile_picker">
+								<input
+									matStartDate
+									formControlName="date_start"
+									placeholder="Start date"
+									(blur)="onDateChange()"
+									(keyup.enter)="onDateChange()"
+								/>
+								<input
+									matEndDate
+									formControlName="date_end"
+									placeholder="End date"
+									(blur)="onDateChange()"
+									(keyup.enter)="onDateChange()"
+								/>
+							</mat-date-range-input>
+							<orc-form-daterange-scroll-picker
+								matIconSuffix
+								[preset_options]="preset_options"
+								[date_start]="panel.controls.daterange.controls.date_start.value"
+								[date_end]="panel.controls.daterange.controls.date_end.value"
+								[active_preset]="page_settings().date_preset"
+								[device_type]="device_type()"
+								(presetChange)="onPresetChange($event)"
+								(dateRangeChange)="onDateRangeChange($event)"
+								(closed)="onDateChange()"
+							></orc-form-daterange-scroll-picker>
+							<mat-date-range-picker #mobile_picker></mat-date-range-picker>
+							<mat-error class="font-size-xs">Invalid date range</mat-error>
+						</mat-form-field>
+					}
 				</div>
 				<div class="orc-filter-menu-rule"></div>
 				<div class="orc-filter-menu-section">

--- a/src/client/modules/system/components/system-control/system-control.component.spec.ts
+++ b/src/client/modules/system/components/system-control/system-control.component.spec.ts
@@ -2,6 +2,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 /* Vendor Dependencies */
 import {MatIconTestingModule} from '@angular/material/icon/testing';
+import {DateTime} from 'luxon';
 /* Native Dependencies */
 import {OrcSystemModule} from '@client/modules/system/system.module';
 /* Application Dependencies */
@@ -43,6 +44,16 @@ describe('SystemControlComponent', () => {
 		component.onClearFilter();
 		expect(preset_spy).toHaveBeenCalledWith(DateRangePreset.Last7Days);
 		expect(interval_spy).toHaveBeenCalledWith(SystemMetricsInterval.Hour);
+	});
+
+	it('should emit a day-snapped range on a manual date change when no sub-day window is active', () => {
+		const spy = spyOn(component.dateChange, 'emit');
+		const start = DateTime.fromSeconds(1_000_000);
+		const end = DateTime.fromSeconds(2_000_000);
+		component.panel.controls.daterange.controls.date_start.setValue(start);
+		component.panel.controls.daterange.controls.date_end.setValue(end);
+		component.onDateChange();
+		expect(spy).toHaveBeenCalledWith([Math.floor(start.toSeconds()), Math.floor(end.endOf('day').toSeconds())]);
 	});
 
 	describe('sub-day window', () => {

--- a/src/client/modules/system/components/system-control/system-control.component.spec.ts
+++ b/src/client/modules/system/components/system-control/system-control.component.spec.ts
@@ -38,12 +38,12 @@ describe('SystemControlComponent', () => {
 		expect(component).toBeTruthy();
 	});
 
-	it('should reset to the last-7-days preset and hourly interval on clear', () => {
+	it('should reset to the last-7-days preset on clear and leave the interval to the parent', () => {
 		const preset_spy = spyOn(component.presetChange, 'emit');
 		const interval_spy = spyOn(component.intervalChange, 'emit');
 		component.onClearFilter();
 		expect(preset_spy).toHaveBeenCalledWith(DateRangePreset.Last7Days);
-		expect(interval_spy).toHaveBeenCalledWith(SystemMetricsInterval.Hour);
+		expect(interval_spy).not.toHaveBeenCalled();
 	});
 
 	it('should emit a day-snapped range on a manual date change when no sub-day window is active', () => {

--- a/src/client/modules/system/components/system-control/system-control.component.spec.ts
+++ b/src/client/modules/system/components/system-control/system-control.component.spec.ts
@@ -44,4 +44,40 @@ describe('SystemControlComponent', () => {
 		expect(preset_spy).toHaveBeenCalledWith(DateRangePreset.Last7Days);
 		expect(interval_spy).toHaveBeenCalledWith(SystemMetricsInterval.Hour);
 	});
+
+	describe('sub-day window', () => {
+		const applySubDayPreset = () => {
+			fixture.componentRef.setInput('page_settings', {
+				date_start: 0,
+				date_end: 900,
+				date_preset: DateRangePreset.Last15Minutes,
+				interval: SystemMetricsInterval.Minute,
+			});
+			fixture.detectChanges();
+		};
+
+		it('flags a sub-day window and exposes its label when a sub-day preset is active', () => {
+			applySubDayPreset();
+			expect(component.is_sub_day_window()).toBe(true);
+			expect(component.sub_day_label()).toBe('Last 15 minutes');
+		});
+
+		it('treats day-granularity presets as a regular date range', () => {
+			fixture.componentRef.setInput('page_settings', {
+				date_start: 0,
+				date_end: 86400,
+				date_preset: DateRangePreset.Last7Days,
+				interval: SystemMetricsInterval.Hour,
+			});
+			fixture.detectChanges();
+			expect(component.is_sub_day_window()).toBe(false);
+		});
+
+		it('does not day-snap or emit a date change while a sub-day window is active', () => {
+			applySubDayPreset();
+			const spy = spyOn(component.dateChange, 'emit');
+			component.onDateChange();
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/client/modules/system/components/system-control/system-control.component.ts
+++ b/src/client/modules/system/components/system-control/system-control.component.ts
@@ -144,10 +144,9 @@ export class SystemControlComponent {
 		return false;
 	}
 
-	/** Resets the panel to default filters — last 7 days and hourly interval — then closes the menu */
+	/** Resets the panel to the default preset — the parent derives the matching interval — then closes the menu */
 	public onClearFilter(): void {
 		this.presetChange.emit(DateRangePreset.Last7Days);
-		this.intervalChange.emit(SystemMetricsInterval.Hour);
 		this.filter_menu_trigger()?.closeMenu();
 	}
 

--- a/src/client/modules/system/components/system-control/system-control.component.ts
+++ b/src/client/modules/system/components/system-control/system-control.component.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {ChangeDetectionStrategy, Component, effect, input, output, untracked, viewChild} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, effect, input, output, untracked, viewChild} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 /* Vendor Dependencies */
 import {MatSelectChange} from '@angular/material/select';
@@ -8,7 +8,8 @@ import {DateRange} from '@angular/material/datepicker';
 import {DateTime} from 'luxon';
 /* Application Dependencies */
 import {NonNullableSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
-import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+import {DateRangePreset, DateRangePresetOption, METRICS_DATE_RANGE_PRESET_OPTIONS} from '@client/modules/form/types/form-daterange.types';
+import {getDateRangePresetLabel, isSubDayDateRangePreset} from '@client/modules/form/helpers/form-daterange.helpers';
 import {DeviceType} from '@client/modules/layout/types/device.types';
 /* Native Dependencies */
 import {SystemIntervalOption} from '@client/modules/system/types/system.types';
@@ -44,6 +45,12 @@ export class SystemControlComponent {
 		{label: 'Hour', value: SystemMetricsInterval.Hour},
 		{label: 'Day', value: SystemMetricsInterval.Day},
 	];
+
+	public readonly preset_options: DateRangePresetOption[] = METRICS_DATE_RANGE_PRESET_OPTIONS;
+
+	// True when the active preset is a rolling sub-day window — the trigger shows a label instead of a date range
+	public readonly is_sub_day_window = computed(() => isSubDayDateRangePreset(this.page_settings().date_preset));
+	public readonly sub_day_label = computed(() => getDateRangePresetLabel(this.page_settings().date_preset));
 
 	public get height_state(): string {
 		return this.panel?.invalid ? 'invalid' : 'valid';
@@ -95,14 +102,20 @@ export class SystemControlComponent {
 		this.presetChange.emit(preset);
 	}
 
-	/** Handles calendar date range selection — updates form controls and emits */
+	/** Handles calendar date range selection — updates form controls and emits a day-granularity range */
 	public onDateRangeChange(range: DateRange<DateTime>): void {
 		if (range.start) this.panel.controls.daterange.controls.date_start.setValue(range.start);
 		if (range.end) this.panel.controls.daterange.controls.date_end.setValue(range.end);
-		this.onDateChange();
+		this.emitDateChange();
 	}
 
+	/** Fires on manual input blur/enter and on picker close — skips sub-day windows, which are preset-driven */
 	public onDateChange(): void {
+		if (this.is_sub_day_window()) return;
+		this.emitDateChange();
+	}
+
+	private emitDateChange(): void {
 		if (this.panel.invalid) return;
 		if (!this.isValidChange()) return;
 		if (this.panel.controls.daterange.controls.date_start.value === null) return;

--- a/src/client/modules/system/constants/system.constants.ts
+++ b/src/client/modules/system/constants/system.constants.ts
@@ -1,2 +1,24 @@
+/* Vendor Dependencies */
+import {DurationLike} from 'luxon';
+/* Application Dependencies */
+import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
+/* Shared Dependencies */
+import {SystemMetricsInterval} from '@shared/generated.types';
+
 /** Number of days the server retains metric samples */
 export const METRICS_RETENTION_DAYS = 90;
+
+/** Rolling window duration and suggested chart interval for each metrics preset */
+export const METRICS_PRESET_META: Partial<Record<DateRangePreset, {duration: DurationLike; interval: SystemMetricsInterval}>> = {
+	[DateRangePreset.Last5Minutes]: {duration: {minutes: 5}, interval: SystemMetricsInterval.Minute},
+	[DateRangePreset.Last15Minutes]: {duration: {minutes: 15}, interval: SystemMetricsInterval.Minute},
+	[DateRangePreset.Last30Minutes]: {duration: {minutes: 30}, interval: SystemMetricsInterval.Minute},
+	[DateRangePreset.Last1Hour]: {duration: {hours: 1}, interval: SystemMetricsInterval.Minute},
+	[DateRangePreset.Last6Hours]: {duration: {hours: 6}, interval: SystemMetricsInterval.Hour},
+	[DateRangePreset.Last12Hours]: {duration: {hours: 12}, interval: SystemMetricsInterval.Hour},
+	[DateRangePreset.Last24Hours]: {duration: {hours: 24}, interval: SystemMetricsInterval.Hour},
+	[DateRangePreset.Last2Days]: {duration: {days: 2}, interval: SystemMetricsInterval.Hour},
+	[DateRangePreset.Last7Days]: {duration: {days: 7}, interval: SystemMetricsInterval.Day},
+	[DateRangePreset.Last30Days]: {duration: {days: 30}, interval: SystemMetricsInterval.Day},
+	[DateRangePreset.Last90Days]: {duration: {days: 90}, interval: SystemMetricsInterval.Day},
+};

--- a/src/client/modules/system/helpers/system-settings.helpers.spec.ts
+++ b/src/client/modules/system/helpers/system-settings.helpers.spec.ts
@@ -9,6 +9,7 @@ import {
 	resolveMetricsDateRangePreset,
 	suggestMetricsInterval,
 	refreshMetricsRange,
+	shouldAutoRefreshMetrics,
 	getMetricsGenesisTime,
 } from './system-settings.helpers';
 /* Shared Dependencies */
@@ -112,6 +113,28 @@ describe('system-settings.helpers', () => {
 		it('passes static custom ranges through unchanged', () => {
 			const static_settings = page_settings();
 			expect(refreshMetricsRange(static_settings)).toBe(static_settings);
+		});
+	});
+
+	describe('shouldAutoRefreshMetrics', () => {
+		it('is true for a rolling minute window', () => {
+			expect(
+				shouldAutoRefreshMetrics(
+					page_settings({interval: SystemMetricsInterval.Minute, date_preset: DateRangePreset.Last15Minutes}),
+				),
+			).toBe(true);
+		});
+
+		it('is false for null settings, static custom ranges, and coarser intervals', () => {
+			expect(shouldAutoRefreshMetrics(null)).toBe(false);
+			expect(shouldAutoRefreshMetrics(page_settings({interval: SystemMetricsInterval.Minute}))).toBe(false);
+			expect(shouldAutoRefreshMetrics(page_settings({date_preset: DateRangePreset.Last6Hours}))).toBe(false);
+		});
+
+		it('is false when the minute interval is manually forced onto a long preset', () => {
+			expect(
+				shouldAutoRefreshMetrics(page_settings({interval: SystemMetricsInterval.Minute, date_preset: DateRangePreset.Last30Days})),
+			).toBe(false);
 		});
 	});
 

--- a/src/client/modules/system/helpers/system-settings.helpers.spec.ts
+++ b/src/client/modules/system/helpers/system-settings.helpers.spec.ts
@@ -1,13 +1,23 @@
+/* Vendor Dependencies */
+import {DateTime} from 'luxon';
 /* Application Dependencies */
-import {resolveDateRangePreset} from '@client/modules/form/helpers/form-daterange.helpers';
 import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
-import {AllSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
+import {AllSystemMetricsSettings, NonNullableSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
 /* Native Dependencies */
-import {resolveSystemMetricsSettings, getMetricsGenesisTime} from './system-settings.helpers';
+import {
+	resolveSystemMetricsSettings,
+	resolveMetricsDateRangePreset,
+	suggestMetricsInterval,
+	refreshMetricsRange,
+	getMetricsGenesisTime,
+} from './system-settings.helpers';
 /* Shared Dependencies */
 import {SystemMetricsInterval} from '@shared/generated.types';
 
-/** Builds a settings object with all fields nulled unless overridden */
+/** Fixed reference time so rolling spans can be asserted exactly (UTC avoids DST-length days) */
+const now = DateTime.fromSeconds(1_750_000_000, {zone: 'utc'});
+
+/** Builds a stored-settings object with all fields nulled unless overridden */
 const settings = (overrides: Partial<AllSystemMetricsSettings> = {}): AllSystemMetricsSettings => ({
 	date_start: null,
 	date_end: null,
@@ -16,27 +26,104 @@ const settings = (overrides: Partial<AllSystemMetricsSettings> = {}): AllSystemM
 	...overrides,
 });
 
+/** Builds a resolved page-settings object with static defaults unless overridden */
+const page_settings = (overrides: Partial<NonNullableSystemMetricsSettings> = {}): NonNullableSystemMetricsSettings => ({
+	date_start: 111,
+	date_end: 222,
+	date_preset: null,
+	interval: SystemMetricsInterval.Hour,
+	...overrides,
+});
+
 describe('system-settings.helpers', () => {
 	describe('getMetricsGenesisTime', () => {
 		it('returns a positive unix-second timestamp in the past', () => {
 			const genesis = getMetricsGenesisTime();
-			const now = Math.floor(Date.now() / 1000);
+			const current = Math.floor(Date.now() / 1000);
 			expect(genesis).toBeGreaterThan(0);
-			expect(genesis).toBeLessThan(now);
+			expect(genesis).toBeLessThan(current);
 			// ~90 days ago, allow a day of slack for start-of-day flooring
-			expect(now - genesis).toBeGreaterThan(89 * 86400);
-			expect(now - genesis).toBeLessThan(91 * 86400);
+			expect(current - genesis).toBeGreaterThan(89 * 86400);
+			expect(current - genesis).toBeLessThan(91 * 86400);
+		});
+	});
+
+	describe('resolveMetricsDateRangePreset', () => {
+		it('resolves sub-day presets to rolling windows ending now', () => {
+			expect(resolveMetricsDateRangePreset(DateRangePreset.Last5Minutes, now)).toEqual({
+				date_start: now.toUnixInteger() - 5 * 60,
+				date_end: now.toUnixInteger(),
+			});
+			expect(resolveMetricsDateRangePreset(DateRangePreset.Last12Hours, now)).toEqual({
+				date_start: now.toUnixInteger() - 12 * 3600,
+				date_end: now.toUnixInteger(),
+			});
+		});
+
+		it('resolves Last2Days to exactly 48 hours ending now with no day snapping', () => {
+			const resolved = resolveMetricsDateRangePreset(DateRangePreset.Last2Days, now);
+			expect(resolved.date_end).toBe(now.toUnixInteger());
+			expect(resolved.date_end - resolved.date_start).toBe(2 * 86400);
+		});
+
+		it('resolves day presets to rolling N-day windows ending now', () => {
+			const resolved_7 = resolveMetricsDateRangePreset(DateRangePreset.Last7Days, now);
+			const resolved_90 = resolveMetricsDateRangePreset(DateRangePreset.Last90Days, now);
+			expect(resolved_7.date_end - resolved_7.date_start).toBe(7 * 86400);
+			expect(resolved_90.date_end - resolved_90.date_start).toBe(90 * 86400);
+			expect(resolved_7.date_end).toBe(now.toUnixInteger());
+		});
+
+		it('falls back to the shared day-pegged resolver for unmapped presets', () => {
+			const resolved = resolveMetricsDateRangePreset(DateRangePreset.AllTime, now);
+			expect(resolved.date_start).toBe(getMetricsGenesisTime());
+		});
+	});
+
+	describe('suggestMetricsInterval', () => {
+		it('maps presets to their suggested interval', () => {
+			expect(suggestMetricsInterval(DateRangePreset.Last5Minutes)).toBe(SystemMetricsInterval.Minute);
+			expect(suggestMetricsInterval(DateRangePreset.Last1Hour)).toBe(SystemMetricsInterval.Minute);
+			expect(suggestMetricsInterval(DateRangePreset.Last6Hours)).toBe(SystemMetricsInterval.Hour);
+			expect(suggestMetricsInterval(DateRangePreset.Last2Days)).toBe(SystemMetricsInterval.Hour);
+			expect(suggestMetricsInterval(DateRangePreset.Last7Days)).toBe(SystemMetricsInterval.Day);
+			expect(suggestMetricsInterval(DateRangePreset.Last90Days)).toBe(SystemMetricsInterval.Day);
+		});
+
+		it('returns null for unmapped or missing presets', () => {
+			expect(suggestMetricsInterval(DateRangePreset.AllTime)).toBeNull();
+			expect(suggestMetricsInterval(null)).toBeNull();
+			expect(suggestMetricsInterval(undefined)).toBeNull();
+		});
+	});
+
+	describe('refreshMetricsRange', () => {
+		it('re-resolves preset-driven settings to a fresh rolling window', () => {
+			const before = Math.floor(Date.now() / 1000);
+			const refreshed = refreshMetricsRange(
+				page_settings({date_start: 0, date_end: 900, date_preset: DateRangePreset.Last15Minutes}),
+			);
+			expect(refreshed.date_end).toBeGreaterThanOrEqual(before);
+			expect(refreshed.date_end - refreshed.date_start).toBe(15 * 60);
+			expect(refreshed.date_preset).toBe(DateRangePreset.Last15Minutes);
+			expect(refreshed.interval).toBe(SystemMetricsInterval.Hour);
+		});
+
+		it('passes static custom ranges through unchanged', () => {
+			const static_settings = page_settings();
+			expect(refreshMetricsRange(static_settings)).toBe(static_settings);
 		});
 	});
 
 	describe('resolveSystemMetricsSettings', () => {
-		it('defaults to a Last7Days range and hourly interval on a first visit', () => {
-			const defaults = resolveDateRangePreset(DateRangePreset.Last7Days);
+		it('defaults to a rolling last-7-days range and daily interval on a first visit', () => {
+			const before = Math.floor(Date.now() / 1000);
 			const resolved = resolveSystemMetricsSettings(settings());
-			expect(resolved.date_start).toBe(defaults.date_start);
-			expect(resolved.date_end).toBe(defaults.date_end);
+			expect(resolved.date_end).toBeGreaterThanOrEqual(before);
+			// wall-clock rolling window; allow an hour of slack for DST transitions in the local zone
+			expect(Math.abs(resolved.date_end - resolved.date_start - 7 * 86400)).toBeLessThanOrEqual(3600);
 			expect(resolved.date_preset).toBeNull();
-			expect(resolved.interval).toBe(SystemMetricsInterval.Hour);
+			expect(resolved.interval).toBe(SystemMetricsInterval.Day);
 		});
 
 		it('uses stored explicit dates and interval when no preset is set', () => {
@@ -49,13 +136,14 @@ describe('system-settings.helpers', () => {
 			expect(resolved.interval).toBe(SystemMetricsInterval.Minute);
 		});
 
-		it('lets a preset override stored explicit dates', () => {
-			const preset_dates = resolveDateRangePreset(DateRangePreset.Last30Days, getMetricsGenesisTime());
+		it('lets a preset override stored explicit dates with a fresh rolling window', () => {
+			const before = Math.floor(Date.now() / 1000);
 			const resolved = resolveSystemMetricsSettings(
 				settings({date_preset: DateRangePreset.Last30Days, date_start: 111, date_end: 222}),
 			);
-			expect(resolved.date_start).toBe(preset_dates.date_start);
-			expect(resolved.date_end).toBe(preset_dates.date_end);
+			expect(resolved.date_end).toBeGreaterThanOrEqual(before);
+			// wall-clock rolling window; allow an hour of slack for DST transitions in the local zone
+			expect(Math.abs(resolved.date_end - resolved.date_start - 30 * 86400)).toBeLessThanOrEqual(3600);
 			expect(resolved.date_preset).toBe(DateRangePreset.Last30Days);
 		});
 
@@ -64,8 +152,26 @@ describe('system-settings.helpers', () => {
 			expect(resolved.date_start).toBe(getMetricsGenesisTime());
 		});
 
-		it('falls back to the hourly interval when none is stored', () => {
-			expect(resolveSystemMetricsSettings(settings({interval: null})).interval).toBe(SystemMetricsInterval.Hour);
+		it('derives the default interval from the stored preset', () => {
+			expect(resolveSystemMetricsSettings(settings({date_preset: DateRangePreset.Last5Minutes})).interval).toBe(
+				SystemMetricsInterval.Minute,
+			);
+			expect(resolveSystemMetricsSettings(settings({date_preset: DateRangePreset.Last2Days})).interval).toBe(
+				SystemMetricsInterval.Hour,
+			);
+		});
+
+		it('keeps a stored interval over the preset-derived one', () => {
+			const resolved = resolveSystemMetricsSettings(
+				settings({date_preset: DateRangePreset.Last5Minutes, interval: SystemMetricsInterval.Day}),
+			);
+			expect(resolved.interval).toBe(SystemMetricsInterval.Day);
+		});
+
+		it('falls back to the hourly interval when no preset or interval is mappable', () => {
+			expect(resolveSystemMetricsSettings(settings({date_preset: DateRangePreset.AllTime})).interval).toBe(
+				SystemMetricsInterval.Hour,
+			);
 		});
 	});
 });

--- a/src/client/modules/system/helpers/system-settings.helpers.ts
+++ b/src/client/modules/system/helpers/system-settings.helpers.ts
@@ -35,6 +35,12 @@ export function refreshMetricsRange(settings: NonNullableSystemMetricsSettings):
 	return {...settings, ...resolveMetricsDateRangePreset(settings.date_preset)};
 }
 
+/** True when settings describe a live rolling minute window (sub-day minute preset) that should auto-advance */
+export function shouldAutoRefreshMetrics(settings: NonNullableSystemMetricsSettings | null): boolean {
+	if (!settings || settings.interval !== SystemMetricsInterval.Minute || !settings.date_preset) return false;
+	return METRICS_PRESET_META[settings.date_preset]?.interval === SystemMetricsInterval.Minute;
+}
+
 /** Resolves stored device settings into fully-defaulted page settings for a first visit */
 export function resolveSystemMetricsSettings(settings: AllSystemMetricsSettings): NonNullableSystemMetricsSettings {
 	const date_preset = settings.date_preset ?? null;

--- a/src/client/modules/system/helpers/system-settings.helpers.ts
+++ b/src/client/modules/system/helpers/system-settings.helpers.ts
@@ -5,7 +5,7 @@ import {resolveDateRangePreset} from '@client/modules/form/helpers/form-daterang
 import {DateRangePreset} from '@client/modules/form/types/form-daterange.types';
 import {AllSystemMetricsSettings, NonNullableSystemMetricsSettings} from '@client/modules/settings/types/setting.types';
 /* Native Dependencies */
-import {METRICS_RETENTION_DAYS} from '@client/modules/system/constants/system.constants';
+import {METRICS_RETENTION_DAYS, METRICS_PRESET_META} from '@client/modules/system/constants/system.constants';
 /* Shared Dependencies */
 import {SystemMetricsInterval} from '@shared/generated.types';
 
@@ -14,15 +14,36 @@ export function getMetricsGenesisTime(): number {
 	return Math.floor(DateTime.now().minus({days: METRICS_RETENTION_DAYS}).startOf('day').toSeconds());
 }
 
+/** Resolves a metrics preset to a rolling window of exactly (now − duration → now), no calendar snapping */
+export function resolveMetricsDateRangePreset(
+	preset: DateRangePreset,
+	now: DateTime = DateTime.now(),
+): {date_start: number; date_end: number} {
+	const meta = METRICS_PRESET_META[preset];
+	if (!meta) return resolveDateRangePreset(preset, getMetricsGenesisTime(), now);
+	return {date_start: now.minus(meta.duration).toUnixInteger(), date_end: now.toUnixInteger()};
+}
+
+/** Suggested chart interval for a metrics preset, or null when the preset has no mapping */
+export function suggestMetricsInterval(preset: DateRangePreset | null | undefined): SystemMetricsInterval | null {
+	return preset != null ? (METRICS_PRESET_META[preset]?.interval ?? null) : null;
+}
+
+/** Re-resolves the rolling window for preset-driven settings; static custom ranges pass through unchanged */
+export function refreshMetricsRange(settings: NonNullableSystemMetricsSettings): NonNullableSystemMetricsSettings {
+	if (!settings.date_preset) return settings;
+	return {...settings, ...resolveMetricsDateRangePreset(settings.date_preset)};
+}
+
 /** Resolves stored device settings into fully-defaulted page settings for a first visit */
 export function resolveSystemMetricsSettings(settings: AllSystemMetricsSettings): NonNullableSystemMetricsSettings {
 	const date_preset = settings.date_preset ?? null;
-	const resolved_dates = date_preset ? resolveDateRangePreset(date_preset, getMetricsGenesisTime()) : null;
-	const default_dates = resolveDateRangePreset(DateRangePreset.Last7Days);
+	const resolved_dates = date_preset ? resolveMetricsDateRangePreset(date_preset) : null;
+	const default_dates = resolveMetricsDateRangePreset(DateRangePreset.Last7Days);
 	return {
 		date_start: resolved_dates?.date_start ?? settings.date_start ?? default_dates.date_start,
 		date_end: resolved_dates?.date_end ?? settings.date_end ?? default_dates.date_end,
 		date_preset,
-		interval: settings.interval ?? SystemMetricsInterval.Hour,
+		interval: settings.interval ?? suggestMetricsInterval(date_preset ?? DateRangePreset.Last7Days) ?? SystemMetricsInterval.Hour,
 	};
 }

--- a/src/client/modules/system/system.module.ts
+++ b/src/client/modules/system/system.module.ts
@@ -6,6 +6,7 @@ import {ReactiveFormsModule as CoreReactiveFormsModule} from '@angular/forms';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {MatMenuModule} from '@angular/material/menu';
 import {MatDatepickerModule} from '@angular/material/datepicker';
@@ -26,6 +27,7 @@ import {SystemChartComponent} from './components/system-chart/system-chart.compo
 		MatIconModule,
 		MatButtonModule,
 		MatFormFieldModule,
+		MatInputModule,
 		MatSelectModule,
 		MatMenuModule,
 		MatDatepickerModule,


### PR DESCRIPTION
## New Features

- **Sub-day metrics date ranges** — the System metrics picker adds rolling quick-selects (5m, 15m, 30m, 1h, 6h, 12h, 24h) alongside day windows (2d, 7d, 30d, 90d).
- **Rolling window label** — when a sub-day window is active, the field shows its label (e.g. "Last 15 minutes") instead of two dates.

## Changes

- **Metrics presets capped at retention** — quarter/year/all-time dropped from the metrics picker since data stops at 90 days.
- **Shared picker unchanged elsewhere** — sub-day options are opt-in via a new `preset_options` input; the five other date-range surfaces keep the day-only list.
- **Wider preset column** — so "Last 30 minutes" no longer truncates against "Last 30 days".

## Bug Fixes

- **No day-snap on rolling windows** — sub-day selections resolve to a true `now − N` range and are guarded against being flattened to whole days on picker close.

## Testing

- Unit tests for preset resolution, sub-day detection, the label swap, and the day-snapped emit path.