### PR TITLE
chore: single navigation source

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,6 +19,9 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
+            "allowedCommonJsDependencies": [
+              "qr-code-styling"
+            ],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "src/client/styles"

--- a/src/client/modules/auth/modules/auth-section/components/auth-section/auth-section.component.ts
+++ b/src/client/modules/auth/modules/auth-section/components/auth-section/auth-section.component.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {ChangeDetectionStrategy, Component, WritableSignal, signal, OnInit, OnDestroy} from '@angular/core';
+import {ChangeDetectionStrategy, Component, signal, OnInit, OnDestroy} from '@angular/core';
 import {Router, NavigationStart, NavigationEnd, NavigationCancel, NavigationError} from '@angular/router';
 /* Vendor Dependencies */
 import {Subscription} from 'rxjs';
@@ -12,7 +12,7 @@ import {Subscription} from 'rxjs';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AuthSectionComponent implements OnInit, OnDestroy {
-	public overlayed: WritableSignal<boolean> = signal(false);
+	public overlayed = signal<boolean>(false);
 
 	private subscriptions: Subscription = new Subscription();
 

--- a/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.html
+++ b/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.html
@@ -7,10 +7,13 @@
 			</div>
 		</div>
 		<div nav-secondary-items>
-			<orc-nav-secondary-item name="Dashboard" navroute="bitcoin" [active]="active_sub_section() === 'dashboard'">
-			</orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Oracle" navroute="bitcoin/oracle" [active]="active_sub_section() === 'oracle'">
-			</orc-nav-secondary-item>
+			@for (item of menu_items; track item.navroute) {
+				<orc-nav-secondary-item
+					[name]="item.name"
+					[navroute]="item.navroute"
+					[active]="active_sub_section() === item.subsection"
+				></orc-nav-secondary-item>
+			}
 		</div>
 		<div nav-secondary-toolbar class="nav-secondary-toolbar">
 			<div class="section-implementation">{{ bitcoin_network_info()?.subversion }}</div>

--- a/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.spec.ts
+++ b/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.spec.ts
@@ -1,6 +1,8 @@
 /* Core Dependencies */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideRouter} from '@angular/router';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 /* Native Dependencies */
 import {OrcBitcoinSectionModule} from '@client/modules/bitcoin/modules/bitcoin-section/bitcoin-section.module';
 /* Local Dependencies */
@@ -23,5 +25,9 @@ describe('BitcoinSectionComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should source menu items from the nav service', () => {
+		expect(component.menu_items).toEqual(TestBed.inject(NavService).getMenuItems('bitcoin'));
 	});
 });

--- a/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.ts
+++ b/src/client/modules/bitcoin/modules/bitcoin-section/components/bitcoin-section/bitcoin-section.component.ts
@@ -1,8 +1,11 @@
 /* Core Dependencies */
-import {Component, ChangeDetectionStrategy, OnInit, OnDestroy, signal, WritableSignal} from '@angular/core';
+import {Component, ChangeDetectionStrategy, OnInit, OnDestroy, signal, inject} from '@angular/core';
 import {Router, Event, ActivatedRoute, NavigationStart, NavigationEnd, NavigationCancel, NavigationError} from '@angular/router';
 /* Vendor Dependencies */
 import {filter, Subscription} from 'rxjs';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
+import {NavSecondaryItem} from '@client/modules/nav/types/nav-secondary-item.type';
 /* Native Dependencies */
 import {BitcoinService} from '@client/modules/bitcoin/services/bitcoin/bitcoin.service';
 import {BitcoinNetworkInfo} from '@client/modules/bitcoin/classes/bitcoin-network-info.class';
@@ -16,18 +19,19 @@ import {BitcoinBlockchainInfo} from '@client/modules/bitcoin/classes/bitcoin-blo
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BitcoinSectionComponent implements OnInit, OnDestroy {
-	public bitcoin_blockchain_info: WritableSignal<BitcoinBlockchainInfo | null> = signal(null);
-	public bitcoin_network_info: WritableSignal<BitcoinNetworkInfo | null> = signal(null);
-	public active_sub_section: WritableSignal<string> = signal('');
-	public overlayed: WritableSignal<boolean> = signal(false);
+	private readonly navService = inject(NavService);
+	private readonly bitcoinService = inject(BitcoinService);
+	private readonly router = inject(Router);
+	private readonly route = inject(ActivatedRoute);
+
+	public readonly menu_items: NavSecondaryItem[] = this.navService.getMenuItems('bitcoin');
+
+	public bitcoin_blockchain_info = signal<BitcoinBlockchainInfo | null>(null);
+	public bitcoin_network_info = signal<BitcoinNetworkInfo | null>(null);
+	public active_sub_section = signal<string>('');
+	public overlayed = signal<boolean>(false);
 
 	private subscriptions: Subscription = new Subscription();
-
-	constructor(
-		private bitcoinService: BitcoinService,
-		private router: Router,
-		private route: ActivatedRoute,
-	) {}
 
 	ngOnInit(): void {
 		this.bitcoinService.loadBitcoinNetworkInfo().subscribe({

--- a/src/client/modules/bitcoin/modules/bitcoin-subsection-oracle/components/bitcoin-subsection-oracle-chart/bitcoin-subsection-oracle-chart.component.ts
+++ b/src/client/modules/bitcoin/modules/bitcoin-subsection-oracle/components/bitcoin-subsection-oracle-chart/bitcoin-subsection-oracle-chart.component.ts
@@ -8,7 +8,6 @@ import {
 	signal,
 	untracked,
 	viewChild,
-	WritableSignal,
 	OnDestroy,
 } from '@angular/core';
 /* Vendor Dependencies */
@@ -45,12 +44,12 @@ export class BitcoinSubsectionOracleChartComponent implements OnDestroy {
 
 	public backfill_date = output<number>();
 
-	public chart_type: WritableSignal<ChartJsType> = signal('line');
-	public chart_data: WritableSignal<ChartConfiguration['data']> = signal({datasets: []});
-	public chart_options: WritableSignal<ChartConfiguration['options']> = signal({});
-	public chart_plugins: WritableSignal<Plugin[]> = signal([]);
-	public displayed: WritableSignal<boolean> = signal(false);
-	public animations_embedded_enabled: WritableSignal<boolean> = signal(false);
+	public chart_type = signal<ChartJsType>('line');
+	public chart_data = signal<ChartConfiguration['data']>({datasets: []});
+	public chart_options = signal<ChartConfiguration['options']>({});
+	public chart_plugins = signal<Plugin[]>([]);
+	public displayed = signal<boolean>(false);
+	public animations_embedded_enabled = signal<boolean>(false);
 
 	private subscriptions: Subscription = new Subscription();
 	private animations_chart_enabled: boolean = true;

--- a/src/client/modules/bitcoin/modules/bitcoin-subsection-oracle/components/bitcoin-subsection-oracle-chart/bitcoin-subsection-oracle-chart.component.ts
+++ b/src/client/modules/bitcoin/modules/bitcoin-subsection-oracle/components/bitcoin-subsection-oracle-chart/bitcoin-subsection-oracle-chart.component.ts
@@ -1,15 +1,5 @@
 /* Core Dependencies */
-import {
-	ChangeDetectionStrategy,
-	Component,
-	input,
-	output,
-	effect,
-	signal,
-	untracked,
-	viewChild,
-	OnDestroy,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, input, output, effect, signal, untracked, viewChild, OnDestroy} from '@angular/core';
 /* Vendor Dependencies */
 import {BaseChartDirective} from 'ng2-charts';
 import {ChartConfiguration, ChartType as ChartJsType, Plugin} from 'chart.js';

--- a/src/client/modules/index/modules/index-section/components/index-section/index-section.component.html
+++ b/src/client/modules/index/modules/index-section/components/index-section/index-section.component.html
@@ -4,9 +4,13 @@
 			<div class="font-size-s">Orchard</div>
 		</div>
 		<div nav-secondary-items>
-			<orc-nav-secondary-item name="Home" navroute="" [active]="active_sub_section() === 'home'"></orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Crew" navroute="crew" [active]="active_sub_section() === 'crew'"></orc-nav-secondary-item>
-			<orc-nav-secondary-item name="System" navroute="system" [active]="active_sub_section() === 'system'"></orc-nav-secondary-item>
+			@for (item of menu_items; track item.navroute) {
+				<orc-nav-secondary-item
+					[name]="item.name"
+					[navroute]="item.navroute"
+					[active]="active_sub_section() === item.subsection"
+				></orc-nav-secondary-item>
+			}
 		</div>
 		<div nav-secondary-toolbar class="nav-secondary-toolbar">
 			<div class="section-implementation">{{ version() }}</div>

--- a/src/client/modules/index/modules/index-section/components/index-section/index-section.component.spec.ts
+++ b/src/client/modules/index/modules/index-section/components/index-section/index-section.component.spec.ts
@@ -3,6 +3,8 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {RouterOutlet, ActivatedRoute} from '@angular/router';
 /* Vendor Dependencies */
 import {of} from 'rxjs';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 /* Native Dependencies */
 import {OrcIndexSectionModule} from '@client/modules/index/modules/index-section/index-section.module';
 /* Local Dependencies */
@@ -35,5 +37,9 @@ describe('IndexSectionComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should source menu items from the nav service', () => {
+		expect(component.menu_items).toEqual(TestBed.inject(NavService).getMenuItems('index'));
 	});
 });

--- a/src/client/modules/index/modules/index-section/components/index-section/index-section.component.ts
+++ b/src/client/modules/index/modules/index-section/components/index-section/index-section.component.ts
@@ -1,10 +1,12 @@
 /* Core Dependencies */
-import {ChangeDetectionStrategy, Component, WritableSignal, signal, OnInit, OnDestroy} from '@angular/core';
+import {ChangeDetectionStrategy, Component, signal, OnInit, OnDestroy, inject} from '@angular/core';
 import {Router, Event, ActivatedRoute, NavigationStart, NavigationEnd, NavigationCancel, NavigationError} from '@angular/router';
 /* Vendor Dependencies */
 import {filter, Subscription} from 'rxjs';
 /* Application Dependencies */
 import {ConfigService} from '@client/modules/config/services/config.service';
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
+import {NavSecondaryItem} from '@client/modules/nav/types/nav-secondary-item.type';
 
 @Component({
 	selector: 'orc-index-section',
@@ -14,17 +16,20 @@ import {ConfigService} from '@client/modules/config/services/config.service';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexSectionComponent implements OnInit, OnDestroy {
-	public version: WritableSignal<string> = signal('');
-	public active_sub_section: WritableSignal<string> = signal('');
-	public overlayed: WritableSignal<boolean> = signal(false);
+	private readonly navService = inject(NavService);
+	private readonly configService = inject(ConfigService);
+	private readonly router = inject(Router);
+	private readonly route = inject(ActivatedRoute);
+
+	public readonly menu_items: NavSecondaryItem[] = this.navService.getMenuItems('index');
+
+	public version = signal<string>('');
+	public active_sub_section = signal<string>('');
+	public overlayed = signal<boolean>(false);
 
 	private subscriptions: Subscription = new Subscription();
 
-	constructor(
-		private configService: ConfigService,
-		private router: Router,
-		private route: ActivatedRoute,
-	) {
+	constructor() {
 		this.version.set(this.configService.config.mode.version);
 	}
 

--- a/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.html
+++ b/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.html
@@ -2,16 +2,21 @@
 	<orc-nav-secondary>
 		<div nav-secondary-header class="nav-secondary-header">
 			<div class="flex flex-items-center flex-gap-1">
-				<div class="h-2 w-2 orc-corner-full" [style.background-color]="lightning_info?.color"></div>
-				<div class="text-nowrap">{{ lightning_info?.alias }}</div>
+				<div class="h-2 w-2 orc-corner-full" [style.background-color]="lightning_info()?.color"></div>
+				<div class="text-nowrap">{{ lightning_info()?.alias }}</div>
 			</div>
 		</div>
 		<div nav-secondary-items>
-			<orc-nav-secondary-item name="Dashboard" navroute="lightning" [active]="active_sub_section() === 'dashboard'">
-			</orc-nav-secondary-item>
+			@for (item of menu_items; track item.navroute) {
+				<orc-nav-secondary-item
+					[name]="item.name"
+					[navroute]="item.navroute"
+					[active]="active_sub_section() === item.subsection"
+				></orc-nav-secondary-item>
+			}
 		</div>
 		<div nav-secondary-toolbar class="nav-secondary-toolbar">
-			<div class="section-implementation">{{ lightning_info?.version }}</div>
+			<div class="section-implementation">{{ lightning_info()?.version }}</div>
 			<orc-nav-secondary-more></orc-nav-secondary-more>
 		</div>
 	</orc-nav-secondary>

--- a/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.spec.ts
+++ b/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.spec.ts
@@ -1,6 +1,8 @@
 /* Core Dependencies */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideRouter} from '@angular/router';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 /* Native Dependencies */
 import {OrcLightningSectionModule} from '@client/modules/lightning/modules/lightning-section/lightning-section.module';
 /* Local Dependencies */
@@ -23,5 +25,9 @@ describe('LightningSectionComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should source menu items from the nav service', () => {
+		expect(component.menu_items).toEqual(TestBed.inject(NavService).getMenuItems('lightning'));
 	});
 });

--- a/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.ts
+++ b/src/client/modules/lightning/modules/lightning-section/components/lightning-section/lightning-section.component.ts
@@ -1,6 +1,9 @@
 /* Core Dependencies */
-import {Component, ChangeDetectionStrategy, OnInit, ChangeDetectorRef, OnDestroy, WritableSignal, signal} from '@angular/core';
+import {Component, ChangeDetectionStrategy, OnInit, OnDestroy, signal, inject} from '@angular/core';
 import {Router, Event, ActivatedRoute, NavigationStart} from '@angular/router';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
+import {NavSecondaryItem} from '@client/modules/nav/types/nav-secondary-item.type';
 /* Native Dependencies */
 import {LightningService} from '@client/modules/lightning/services/lightning/lightning.service';
 import {LightningInfo} from '@client/modules/lightning/classes/lightning-info.class';
@@ -15,27 +18,26 @@ import {filter, Subscription} from 'rxjs';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LightningSectionComponent implements OnInit, OnDestroy {
-	public lightning_info: LightningInfo | null = null;
-	public active_sub_section: WritableSignal<string> = signal('');
-	public loading: boolean = true;
-	public error: boolean = false;
+	private readonly navService = inject(NavService);
+	private readonly lightningService = inject(LightningService);
+	private readonly router = inject(Router);
+	private readonly route = inject(ActivatedRoute);
+
+	public readonly menu_items: NavSecondaryItem[] = this.navService.getMenuItems('lightning');
+
+	public lightning_info = signal<LightningInfo | null>(null);
+	public active_sub_section = signal<string>('');
+	public loading = signal<boolean>(true);
+	public error = signal<boolean>(false);
 
 	private subscriptions: Subscription = new Subscription();
-
-	constructor(
-		private lightningService: LightningService,
-		private router: Router,
-		private route: ActivatedRoute,
-		private cdr: ChangeDetectorRef,
-	) {}
 
 	ngOnInit(): void {
 		this.lightningService.loadLightningInfo().subscribe({
 			error: (error) => {
 				console.error(error);
-				this.error = true;
-				this.loading = false;
-				this.cdr.detectChanges();
+				this.error.set(true);
+				this.loading.set(false);
 			},
 		});
 		this.subscriptions.add(this.getLightningInfoSubscription());
@@ -44,8 +46,9 @@ export class LightningSectionComponent implements OnInit, OnDestroy {
 
 	private getLightningInfoSubscription(): Subscription {
 		return this.lightningService.lightning_info$.subscribe((info: LightningInfo | null) => {
-			if (info) this.lightning_info = info;
-			this.cdr.detectChanges();
+			if (!info) return;
+			this.lightning_info.set(info);
+			this.loading.set(false);
 		});
 	}
 

--- a/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.html
+++ b/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.html
@@ -5,17 +5,13 @@
 			<orc-mint-general-name [name]="mint_info()?.name ?? null" [loading]="loading()" [error]="error()"> </orc-mint-general-name>
 		</div>
 		<div nav-secondary-items>
-			<orc-nav-secondary-item name="Dashboard" navroute="mint" [active]="active_sub_section() === 'dashboard'">
-			</orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Info" navroute="mint/info" [active]="active_sub_section() === 'info'"> </orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Config" navroute="mint/config" [active]="active_sub_section() === 'config'">
-			</orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Keysets" navroute="mint/keysets" [active]="active_sub_section() === 'keysets'">
-			</orc-nav-secondary-item>
-			<orc-nav-secondary-item name="Database" navroute="mint/database" [active]="active_sub_section() === 'database'">
-			</orc-nav-secondary-item>
-			<orc-nav-secondary-item name="System" navroute="mint/system" [active]="active_sub_section() === 'system'">
-			</orc-nav-secondary-item>
+			@for (item of menu_items; track item.navroute) {
+				<orc-nav-secondary-item
+					[name]="item.name"
+					[navroute]="item.navroute"
+					[active]="active_sub_section() === item.subsection"
+				></orc-nav-secondary-item>
+			}
 		</div>
 		<div nav-secondary-toolbar class="nav-secondary-toolbar">
 			<div class="section-implementation">{{ mint_info()?.version }}</div>

--- a/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.spec.ts
+++ b/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.spec.ts
@@ -1,6 +1,8 @@
 /* Core Dependencies */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideRouter} from '@angular/router';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 /* Native Dependencies */
 import {OrcMintSectionModule} from '@client/modules/mint/modules/mint-section/mint-section.module';
 /* Local Dependencies */
@@ -23,5 +25,9 @@ describe('MintSectionComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should source menu items from the nav service', () => {
+		expect(component.menu_items).toEqual(TestBed.inject(NavService).getMenuItems('mint'));
 	});
 });

--- a/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.ts
+++ b/src/client/modules/mint/modules/mint-section/components/mint-section/mint-section.component.ts
@@ -6,8 +6,10 @@ import {filter, Subscription} from 'rxjs';
 /* Application Dependencies */
 import {MintService} from '@client/modules/mint/services/mint/mint.service';
 import {PublicService} from '@client/modules/public/services/image/public.service';
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 import {MintInfo} from '@client/modules/mint/classes/mint-info.class';
 import {PublicImage} from '@client/modules/public/classes/public-image.class';
+import {NavSecondaryItem} from '@client/modules/nav/types/nav-secondary-item.type';
 
 @Component({
 	selector: 'orc-mint-section',
@@ -21,6 +23,9 @@ export class MintSectionComponent implements OnInit, OnDestroy {
 	private readonly route = inject(ActivatedRoute);
 	private readonly mintService = inject(MintService);
 	private readonly publicService = inject(PublicService);
+	private readonly navService = inject(NavService);
+
+	public readonly menu_items: NavSecondaryItem[] = this.navService.getMenuItems('mint');
 
 	public readonly mint_info = signal<MintInfo | null>(null);
 	public readonly icon_data = signal<string | null>(null);

--- a/src/client/modules/mint/modules/mint-subsection-config/components/mint-subsection-config/mint-subsection-config.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-config/components/mint-subsection-config/mint-subsection-config.component.ts
@@ -4,7 +4,6 @@ import {
 	Component,
 	OnInit,
 	OnDestroy,
-	WritableSignal,
 	signal,
 	ChangeDetectorRef,
 	HostListener,
@@ -189,7 +188,7 @@ export class MintSubsectionConfigComponent implements ComponentCanDeactivate, On
 
 	private subscriptions: Subscription = new Subscription();
 	private active_event: EventData | null = null;
-	private dirty_count: WritableSignal<number> = signal(0);
+	private dirty_count = signal<number>(0);
 	private dirty_count$ = toObservable(this.dirty_count);
 	private scroll_to: string | null = null;
 

--- a/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.html
+++ b/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.html
@@ -3,7 +3,7 @@
 		<div class="summary-grid" [class.p-h-1]="device_type() === 'desktop'" #summary_container>
 			<div class="summary-mint">
 				<div class="chart-target summary1" #summary1></div>
-				<div class="flex flex-column flex-gap-2">
+				<div class="flex flex-column flex-gap-2 p-b-1">
 					<div class="flex flex-row flex-gap-2 flex-wrap">
 						<div class="flex-1">
 							<orc-mint-general-info

--- a/src/client/modules/mint/modules/mint-subsection-info/components/mint-subsection-info/mint-subsection-info.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-info/components/mint-subsection-info/mint-subsection-info.component.ts
@@ -1,13 +1,5 @@
 /* Core Dependencies */
-import {
-	ChangeDetectionStrategy,
-	Component,
-	OnInit,
-	OnDestroy,
-	ChangeDetectorRef,
-	signal,
-	HostListener,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit, OnDestroy, ChangeDetectorRef, signal, HostListener} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
 import {FormGroup, FormControl, Validators, FormArray} from '@angular/forms';
 import {toObservable} from '@angular/core/rxjs-interop';

--- a/src/client/modules/mint/modules/mint-subsection-info/components/mint-subsection-info/mint-subsection-info.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-info/components/mint-subsection-info/mint-subsection-info.component.ts
@@ -5,7 +5,6 @@ import {
 	OnInit,
 	OnDestroy,
 	ChangeDetectorRef,
-	WritableSignal,
 	signal,
 	HostListener,
 } from '@angular/core';
@@ -68,7 +67,7 @@ export class MintSubsectionInfoComponent implements ComponentCanDeactivate, OnIn
 
 	private subscriptions: Subscription = new Subscription();
 	private active_event: EventData | null = null;
-	private dirty_count: WritableSignal<number> = signal(0);
+	private dirty_count = signal<number>(0);
 	private dirty_count$ = toObservable(this.dirty_count);
 
 	constructor(

--- a/src/client/modules/nav/services/nav/nav.service.ts
+++ b/src/client/modules/nav/services/nav/nav.service.ts
@@ -70,6 +70,11 @@ export class NavService {
 				navroute: 'mint/database',
 				subsection: 'database',
 			},
+			{
+				name: 'System',
+				navroute: 'mint/system',
+				subsection: 'system',
+			},
 		],
 		ecash: [
 			{
@@ -80,6 +85,11 @@ export class NavService {
 		],
 		settings: [
 			{
+				name: 'Application',
+				navroute: 'settings/app',
+				subsection: 'app',
+			},
+			{
 				name: 'Device',
 				navroute: 'settings/device',
 				subsection: 'device',
@@ -88,11 +98,6 @@ export class NavService {
 				name: 'User',
 				navroute: 'settings/user',
 				subsection: 'user',
-			},
-			{
-				name: 'App',
-				navroute: 'settings/app',
-				subsection: 'app',
 			},
 		],
 	};

--- a/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.html
+++ b/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.html
@@ -4,21 +4,13 @@
 			<div class="font-size-s">Orchard Settings</div>
 		</div>
 		<div nav-secondary-items>
-			<orc-nav-secondary-item
-				name="Application"
-				navroute="settings/app"
-				[active]="active_sub_section() === 'app'"
-			></orc-nav-secondary-item>
-			<orc-nav-secondary-item
-				name="Device"
-				navroute="settings/device"
-				[active]="active_sub_section() === 'device'"
-			></orc-nav-secondary-item>
-			<orc-nav-secondary-item
-				name="User"
-				navroute="settings/user"
-				[active]="active_sub_section() === 'user'"
-			></orc-nav-secondary-item>
+			@for (item of menu_items; track item.navroute) {
+				<orc-nav-secondary-item
+					[name]="item.name"
+					[navroute]="item.navroute"
+					[active]="active_sub_section() === item.subsection"
+				></orc-nav-secondary-item>
+			}
 		</div>
 		<div nav-secondary-toolbar class="nav-secondary-toolbar">
 			<div class="section-implementation">{{ version() }}</div>

--- a/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.spec.ts
+++ b/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.spec.ts
@@ -1,6 +1,8 @@
 /* Core Dependencies */
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideRouter} from '@angular/router';
+/* Application Dependencies */
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 /* Native Dependencies */
 import {OrcSettingsSectionModule} from '@client/modules/settings/modules/settings-section/settings-section.module';
 /* Local Dependencies */
@@ -23,5 +25,9 @@ describe('SettingsSectionComponent', () => {
 
 	it('should create', () => {
 		expect(component).toBeTruthy();
+	});
+
+	it('should source menu items from the nav service', () => {
+		expect(component.menu_items).toEqual(TestBed.inject(NavService).getMenuItems('settings'));
 	});
 });

--- a/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.ts
+++ b/src/client/modules/settings/modules/settings-section/components/settings-section/settings-section.component.ts
@@ -18,7 +18,9 @@ import {MatSidenav} from '@angular/material/sidenav';
 /* Application Dependencies */
 import {ConfigService} from '@client/modules/config/services/config.service';
 import {FormPanelService} from '@client/modules/form/services/form-panel';
+import {NavService} from '@client/modules/nav/services/nav/nav.service';
 import {DeviceType} from '@client/modules/layout/types/device.types';
+import {NavSecondaryItem} from '@client/modules/nav/types/nav-secondary-item.type';
 
 @Component({
 	selector: 'orc-settings-section',
@@ -34,6 +36,10 @@ export class SettingsSectionComponent implements OnInit, AfterViewInit, OnDestro
 	private readonly route = inject(ActivatedRoute);
 	private readonly breakpointObserver = inject(BreakpointObserver);
 	private readonly formPanelService = inject(FormPanelService);
+	private readonly navService = inject(NavService);
+
+	/* ── Public properties ── */
+	public readonly menu_items: NavSecondaryItem[] = this.navService.getMenuItems('settings');
 
 	/* ── ViewChild references ── */
 	private readonly formSidenav = viewChild<MatSidenav>('formSidenav');

--- a/src/client/modules/settings/modules/settings-subsection-app/components/settings-subsection-app/settings-subsection-app.component.ts
+++ b/src/client/modules/settings/modules/settings-subsection-app/components/settings-subsection-app/settings-subsection-app.component.ts
@@ -3,7 +3,6 @@ import {
 	ChangeDetectionStrategy,
 	Component,
 	HostListener,
-	WritableSignal,
 	signal,
 	effect,
 	inject,
@@ -113,7 +112,7 @@ export class SettingsSubsectionAppComponent implements OnInit, AfterViewInit, On
 
 	private active_event: EventData | null = null;
 	private subscriptions: Subscription = new Subscription();
-	private dirty_count: WritableSignal<number> = signal(0);
+	private dirty_count = signal<number>(0);
 
 	constructor() {
 		effect(() => {

--- a/src/client/modules/settings/modules/settings-subsection-user/components/settings-subsection-user/settings-subsection-user.component.ts
+++ b/src/client/modules/settings/modules/settings-subsection-user/components/settings-subsection-user/settings-subsection-user.component.ts
@@ -1,5 +1,5 @@
 /* Core Dependencies */
-import {ChangeDetectionStrategy, Component, OnInit, OnDestroy, WritableSignal, signal, effect, HostListener} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit, OnDestroy, signal, effect, HostListener} from '@angular/core';
 import {FormGroup, FormControl, Validators} from '@angular/forms';
 import {BreakpointObserver, Breakpoints} from '@angular/cdk/layout';
 /* Vendor Dependencies */
@@ -36,7 +36,7 @@ export class SettingsSubsectionUserComponent implements ComponentCanDeactivate, 
 	public user = signal<User | null>(null);
 	public device_type = signal<DeviceType>('desktop');
 	public settings = signal<ParsedAppSettings | null>(null);
-	private dirty_count: WritableSignal<number> = signal(0);
+	private dirty_count = signal<number>(0);
 
 	private active_event: EventData | null = null;
 	private subscriptions: Subscription = new Subscription();


### PR DESCRIPTION
## Changes
- **Nav menus now share one source of truth** — bitcoin, index, lightning, mint, and settings section navs pull their secondary menu items from `NavService` instead of duplicating markup in each template.
- **Modernized signal declarations** — replaced `WritableSignal<T> = signal(...)` fields with the shorter `readonly ... = signal<T>(...)` form across several components.
- **Lightning section refactored** — switched to `inject()` and signal-driven state, removing manual `ChangeDetectorRef.detectChanges()` calls.
- **Build config allowlists qr-code-styling** — silences an Angular CommonJS-dependency build warning.
- **Mint dashboard spacing tweak** — added bottom padding below the summary column so it doesn't sit flush against the content below.

## Bug Fixes
- **Lightning dashboard loading indicator** — now correctly clears once lightning info arrives, instead of staying stuck on.

## Testing
- Added spec assertions confirming each section component's `menu_items` matches `NavService.getMenuItems(...)` output.