### PR TITLE
chore: Esm tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck Specs
+        run: npm run typecheck:spec
+
       - name: Generate Types
         run: npm run generate:types
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "start:server:nowatch": "NODE_ENV=development nest start",
     "start:server:debug": "NODE_ENV=development nest start --debug --watch",
     "generate:types": "node -r ./scripts/register.cjs scripts/generate-schema.ts && npx graphql-codegen",
+    "typecheck:spec": "tsc -p tsconfig.server.spec.json --noEmit",
+    "ci": "npm run format:check && npm run lint && npm run typecheck:spec && npm run generate:types && npm run test && npm run build",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js && ng test --watch=false --browsers=ChromeHeadless --progress=false",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "generate:types": "node -r ./scripts/register.cjs scripts/generate-schema.ts && npx graphql-codegen",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest && ng test --watch=false --browsers=ChromeHeadless --progress=false",
-    "test:server": "jest",
-    "test:server:watch": "jest --watch",
-    "test:server:cov": "jest --coverage",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js && ng test --watch=false --browsers=ChromeHeadless --progress=false",
+    "test:server": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:server:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
+    "test:server:cov": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
     "test:server:e2e": "./e2e/supertest/scripts/run.sh",
     "test:client": "ng test --watch=false --browsers=ChromeHeadless --progress=false",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:debug": "node --inspect-brk --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand",
     "watch:client": "NODE_ENV=development ng build --watch --configuration development",
     "migration:generate": "NODE_ENV=development node -r ./scripts/register.cjs node_modules/typeorm/cli.js migration:generate -d src/server/database/data-source.ts",
     "migration:run": "NODE_ENV=development node -r ./scripts/register.cjs node_modules/typeorm/cli.js migration:run -d src/server/database/data-source.ts",
@@ -155,16 +155,18 @@
     ],
     "rootDir": "src/server",
     "testRegex": ".*\\.spec\\.ts$",
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
+    "setupFiles": [
+      "<rootDir>/test/jest-esm-globals.ts"
+    ],
     "transform": {
       "^.+\\.(t|j)s$": [
         "ts-jest",
         {
           "tsconfig": "tsconfig.server.spec.json",
-          "diagnostics": {
-            "ignoreCodes": [
-              151002
-            ]
-          }
+          "useESM": true
         }
       ]
     },

--- a/src/server/modules/cashu/cdk/cdk.service.spec.ts
+++ b/src/server/modules/cashu/cdk/cdk.service.spec.ts
@@ -4,13 +4,12 @@ import {expect} from '@jest/globals';
 import {ConfigService} from '@nestjs/config';
 import {Logger} from '@nestjs/common';
 /* Application Dependencies */
+import {mockGrpcModules} from '@server/test/grpc-esm-mocks';
 import {CredentialService} from '@server/modules/credential/credential.service';
 /* Local Dependencies */
-import {CdkService} from './cdk.service.js';
-import * as grpc from '@grpc/grpc-js';
+import type {CdkService as CdkServiceType} from './cdk.service.js';
 
-jest.mock('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
-	__esModule: true,
+jest.unstable_mockModule('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
 	buildDynamicQuery: jest.fn().mockReturnValue({sql: 'SQL', params: []}),
 	buildCountQuery: jest.fn().mockReturnValue({sql: 'COUNTSQL', params: []}),
 	queryRows: jest.fn(),
@@ -18,10 +17,12 @@ jest.mock('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
 	extractRequestString: jest.fn().mockImplementation((s: string) => s?.replace(/^.*:/, '')),
 	convertDateToUnixTimestamp: jest.fn((v: any) => (typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : null)),
 }));
-import * as helpers from '@server/modules/cashu/mintdb/cashumintdb.helpers';
+const helpers = (await import('@server/modules/cashu/mintdb/cashumintdb.helpers')) as any;
+const {proto_loader, grpc} = await mockGrpcModules();
+const {CdkService} = await import('./cdk.service.js');
 
 describe('CdkService', () => {
-	let cdkService: CdkService;
+	let cdkService: CdkServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let credentialService: jest.Mocked<CredentialService>;
 
@@ -36,7 +37,7 @@ describe('CdkService', () => {
 
 		jest.clearAllMocks();
 
-		cdkService = module.get<CdkService>(CdkService);
+		cdkService = module.get(CdkService);
 		configService = module.get(ConfigService);
 		credentialService = module.get(CredentialService);
 	});
@@ -73,14 +74,12 @@ describe('CdkService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		const loadPackageDefinition = jest
-			.spyOn(grpc, 'loadPackageDefinition')
-			.mockReturnValue({cdk_mint_management_v1: {CdkMint: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cdk_mint_management_v1: {CdkMint: jest.fn()}});
 		cdkService.initializeGrpcClient();
 		expect(createSsl).toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
-		expect(loadPackageDefinition).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
+		expect(grpc.loadPackageDefinition).toHaveBeenCalled();
 	});
 
 	it('initializes client with docker channel options when host.docker.internal', () => {
@@ -105,8 +104,8 @@ describe('CdkService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cdk_mint_management_v1: {CdkMint: CdkMintMock}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cdk_mint_management_v1: {CdkMint: CdkMintMock}});
 		cdkService.initializeGrpcClient();
 		expect(CdkMintMock).toHaveBeenCalled();
 		const args = CdkMintMock.mock.calls[0];
@@ -133,8 +132,8 @@ describe('CdkService', () => {
 		const log_spy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined as any);
 		const createInsecure = jest.spyOn(grpc.credentials, 'createInsecure').mockReturnValue({} as any);
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cdk_mint_management_v1: {CdkMint: CdkMintMock}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cdk_mint_management_v1: {CdkMint: CdkMintMock}});
 		const client = cdkService.initializeGrpcClient();
 		expect(client).toBeDefined();
 		expect(createInsecure).toHaveBeenCalled();
@@ -162,7 +161,7 @@ describe('CdkService', () => {
 			}
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
-		jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockImplementation(() => {
+		proto_loader.loadSync.mockImplementation(() => {
 			throw new Error('boom');
 		});
 		const client = cdkService.initializeGrpcClient();

--- a/src/server/modules/cashu/mintdb/cashumintdb.service.spec.ts
+++ b/src/server/modules/cashu/mintdb/cashumintdb.service.spec.ts
@@ -2,34 +2,42 @@
 import {Test, TestingModule} from '@nestjs/testing';
 import {expect} from '@jest/globals';
 /* Local Dependencies */
-import {CashuMintDatabaseService} from './cashumintdb.service.js';
+import type {CashuMintDatabaseService as CashuMintDatabaseServiceType} from './cashumintdb.service.js';
 import {ConfigService} from '@nestjs/config';
 import {CredentialService} from '@server/modules/credential/credential.service';
 import {NutshellService} from '@server/modules/cashu/nutshell/nutshell.service';
 import {CdkService} from '@server/modules/cashu/cdk/cdk.service';
 import {OrchardErrorCode} from '@server/modules/error/error.types';
 import {MintDatabaseType} from './cashumintdb.enums.js';
-import * as child_process from 'child_process';
 import {promises as fs_promises} from 'fs';
 
-jest.mock('pg', () => ({
-	Client: jest.fn().mockImplementation(() => ({})),
-}));
+// Core modules bypass the ESM mock registry, and better-sqlite3 is consumed as a default
+// export, so each module is replaced explicitly. fs.promises is deliberately left real —
+// its spies work because the core namespace is the shared object.
+jest.unstable_mockModule('pg', () => {
+	const mock = {Client: jest.fn().mockImplementation(() => ({}))};
+	return {...mock, default: mock};
+});
 
-jest.mock('better-sqlite3', () => {
-	return jest.fn().mockImplementation(() => ({
+jest.unstable_mockModule('better-sqlite3', () => ({
+	default: jest.fn().mockImplementation(() => ({
 		pragma: jest.fn(),
 		backup: jest.fn(),
 		close: jest.fn(),
-	}));
-});
-
-jest.mock('child_process', () => ({
-	spawn: jest.fn(),
+	})),
 }));
 
+jest.unstable_mockModule('child_process', () => {
+	const mock = {spawn: jest.fn()};
+	return {...mock, default: mock};
+});
+
+const child_process = (await import('child_process')) as any;
+const BetterSqlite3 = ((await import('better-sqlite3')) as any).default;
+const {CashuMintDatabaseService} = await import('./cashumintdb.service.js');
+
 describe('CashuMintDatabaseService', () => {
-	let cashuMintDatabaseService: CashuMintDatabaseService;
+	let cashuMintDatabaseService: CashuMintDatabaseServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let nutshellService: jest.Mocked<NutshellService>;
 	let cdkService: jest.Mocked<CdkService>;
@@ -45,7 +53,7 @@ describe('CashuMintDatabaseService', () => {
 			],
 		}).compile();
 
-		cashuMintDatabaseService = module.get<CashuMintDatabaseService>(CashuMintDatabaseService);
+		cashuMintDatabaseService = module.get(CashuMintDatabaseService);
 		configService = module.get(ConfigService);
 		nutshellService = module.get(NutshellService);
 		cdkService = module.get(CdkService);
@@ -93,7 +101,6 @@ describe('CashuMintDatabaseService', () => {
 	});
 
 	it('getMintDatabase throws MintDatabaseConnectionError on constructor failure', async () => {
-		const BetterSqlite3 = require('better-sqlite3');
 		(BetterSqlite3 as jest.Mock).mockImplementationOnce(() => {
 			throw new Error('boom');
 		});
@@ -122,7 +129,7 @@ describe('CashuMintDatabaseService', () => {
 	it('delegates remaining getters to correct services', async () => {
 		const client = {} as any;
 		const args = {a: 1} as any;
-		const nutshell_map: Array<[keyof CashuMintDatabaseService, keyof NutshellService]> = [
+		const nutshell_map: Array<[keyof CashuMintDatabaseServiceType, keyof NutshellService]> = [
 			['getBalancesIssued', 'getBalancesIssued'],
 			['getBalancesRedeemed', 'getBalancesRedeemed'],
 			['getKeysets', 'getKeysets'],
@@ -149,7 +156,7 @@ describe('CashuMintDatabaseService', () => {
 		nutshell_map.forEach(([_, n_method]) => {
 			(nutshellService[n_method as any] as any) = jest.fn();
 		});
-		const cdk_map: Array<[keyof CashuMintDatabaseService, keyof CdkService]> = [
+		const cdk_map: Array<[keyof CashuMintDatabaseServiceType, keyof CdkService]> = [
 			['getBalancesIssued', 'getBalancesIssued'],
 			['getBalancesRedeemed', 'getBalancesRedeemed'],
 			['getKeysets', 'getKeysets'],
@@ -192,7 +199,6 @@ describe('CashuMintDatabaseService', () => {
 		});
 
 		it('createBackup sqlite: success and cleanup', async () => {
-			const BetterSqlite3 = require('better-sqlite3');
 			const db_instance = new BetterSqlite3();
 			(db_instance.backup as jest.Mock).mockResolvedValue(undefined);
 			const read_file = jest.spyOn(fs_promises, 'readFile').mockResolvedValue(Buffer.from('ok'));
@@ -204,7 +210,6 @@ describe('CashuMintDatabaseService', () => {
 		});
 
 		it('createBackup sqlite: error path cleans up and rethrows', async () => {
-			const BetterSqlite3 = require('better-sqlite3');
 			const db_instance = new BetterSqlite3();
 			(db_instance.backup as jest.Mock).mockRejectedValue(new Error('fail'));
 			const unlink = jest.spyOn(fs_promises, 'unlink').mockResolvedValue(undefined as any);

--- a/src/server/modules/cashu/nutshell/nutshell.service.spec.ts
+++ b/src/server/modules/cashu/nutshell/nutshell.service.spec.ts
@@ -1,27 +1,30 @@
 /* Core Dependencies */
 import {Test, TestingModule} from '@nestjs/testing';
+/* Vendor Dependencies */
+import Database from 'better-sqlite3';
 import {expect} from '@jest/globals';
 import {ConfigService} from '@nestjs/config';
 import {Logger} from '@nestjs/common';
 /* Application Dependencies */
+import {mockGrpcModules} from '@server/test/grpc-esm-mocks';
 import {CredentialService} from '@server/modules/credential/credential.service';
 import {MintDatabaseType} from '@server/modules/cashu/mintdb/cashumintdb.enums';
 /* Local Dependencies */
-import {NutshellService} from './nutshell.service.js';
-import * as grpc from '@grpc/grpc-js';
+import type {NutshellService as NutshellServiceType} from './nutshell.service.js';
 
-jest.mock('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
-	__esModule: true,
+jest.unstable_mockModule('@server/modules/cashu/mintdb/cashumintdb.helpers', () => ({
 	buildDynamicQuery: jest.fn().mockReturnValue({sql: 'SQL', params: []}),
 	buildCountQuery: jest.fn().mockReturnValue({sql: 'COUNTSQL', params: []}),
 	convertDateToUnixTimestamp: jest.fn().mockImplementation((d: any) => (typeof d === 'number' ? d : 1)),
 	queryRows: jest.fn(),
 	queryRow: jest.fn().mockResolvedValue({count: 1}),
 }));
-import * as helpers from '@server/modules/cashu/mintdb/cashumintdb.helpers';
+const helpers = (await import('@server/modules/cashu/mintdb/cashumintdb.helpers')) as any;
+const {proto_loader, grpc} = await mockGrpcModules();
+const {NutshellService} = await import('./nutshell.service.js');
 
 describe('NutshellService', () => {
-	let nutshellService: NutshellService;
+	let nutshellService: NutshellServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let credentialService: jest.Mocked<CredentialService>;
 
@@ -34,7 +37,7 @@ describe('NutshellService', () => {
 			],
 		}).compile();
 
-		nutshellService = module.get<NutshellService>(NutshellService);
+		nutshellService = module.get(NutshellService);
 		configService = module.get(ConfigService);
 		credentialService = module.get(CredentialService);
 		jest.clearAllMocks();
@@ -70,12 +73,12 @@ describe('NutshellService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		const loadPackageDefinition = jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cashu: {Mint: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cashu: {Mint: jest.fn()}});
 		nutshellService.initializeGrpcClient();
 		expect(createSsl).toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
-		expect(loadPackageDefinition).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
+		expect(grpc.loadPackageDefinition).toHaveBeenCalled();
 	});
 
 	it('initializes client with docker host channel options when using mTLS', () => {
@@ -99,9 +102,9 @@ describe('NutshellService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue('DEF' as any);
+		proto_loader.loadSync.mockReturnValue('DEF');
 		const mint_ctor = jest.fn();
-		jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cashu: {Mint: mint_ctor}} as any);
+		grpc.loadPackageDefinition.mockReturnValue({cashu: {Mint: mint_ctor}});
 		nutshellService.initializeGrpcClient();
 		const args = mint_ctor.mock.calls[0];
 		expect(args[2]).toMatchObject({
@@ -125,12 +128,12 @@ describe('NutshellService', () => {
 		});
 		const createInsecure = jest.spyOn(grpc.credentials, 'createInsecure').mockReturnValue({} as any);
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cashu: {Mint: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cashu: {Mint: jest.fn()}});
 		nutshellService.initializeGrpcClient();
 		expect(createInsecure).toHaveBeenCalled();
 		expect(createSsl).not.toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
 	});
 
 	it('initializeGrpcClient logs error and returns undefined when loader throws', () => {
@@ -154,8 +157,7 @@ describe('NutshellService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync');
-		loadSync.mockImplementation(() => {
+		proto_loader.loadSync.mockImplementation(() => {
 			throw new Error('boom');
 		});
 		const logger_error = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined as any);
@@ -188,10 +190,10 @@ describe('NutshellService', () => {
 		const ca_buf = Buffer.from('a');
 		credentialService.loadPemOrPath.mockReturnValueOnce(key_buf).mockReturnValueOnce(cert_buf).mockReturnValueOnce(ca_buf);
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cashu: {Mint: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cashu: {Mint: jest.fn()}});
 		nutshellService.initializeGrpcClient();
-		const load_arg = loadSync.mock.calls[0][0];
+		const load_arg = proto_loader.loadSync.mock.calls[0][0];
 		expect(String(load_arg)).toContain('proto/nutshell/management.proto');
 		expect(createSsl).toHaveBeenCalledWith(ca_buf, key_buf, cert_buf);
 		const logger_log = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined as any);
@@ -424,7 +426,6 @@ describe('NutshellService', () => {
 	});
 
 	it('listFees inner SELECT drops the first row of each partition against an in-memory sqlite', async () => {
-		const Database = require('better-sqlite3');
 		const db = new Database(':memory:');
 		db.exec(`
 			CREATE TABLE balance_log (unit TEXT, time INTEGER, keyset_fees_paid INTEGER);

--- a/src/server/modules/credential/credential.service.spec.ts
+++ b/src/server/modules/credential/credential.service.spec.ts
@@ -1,20 +1,29 @@
 /* Core Dependencies */
 import {Test, TestingModule} from '@nestjs/testing';
 import {expect} from '@jest/globals';
-import * as fs from 'fs';
-jest.mock('fs');
 /* Local Dependencies */
-import {CredentialService} from './credential.service.js';
+import type {CredentialService as CredentialServiceType} from './credential.service.js';
+
+// Core modules bypass the ESM mock registry, and unstable_mockModule has no automock
+// equivalent, so the surface the service uses is stubbed explicitly. existsSync must stay
+// falsy — the isProbablyPath assertions depend on it.
+jest.unstable_mockModule('fs', () => {
+	const mock = {existsSync: jest.fn(), readFileSync: jest.fn()};
+	return {...mock, default: mock};
+});
+
+const fs = (await import('fs')) as any;
+const {CredentialService} = await import('./credential.service.js');
 
 describe('CredentialService', () => {
-	let credentialService: CredentialService;
+	let credentialService: CredentialServiceType;
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
 			providers: [CredentialService],
 		}).compile();
 
-		credentialService = module.get<CredentialService>(CredentialService);
+		credentialService = module.get(CredentialService);
 	});
 
 	it('should be defined', () => {

--- a/src/server/modules/lightning/cln/cln.service.spec.ts
+++ b/src/server/modules/lightning/cln/cln.service.spec.ts
@@ -3,13 +3,16 @@ import {Test, TestingModule} from '@nestjs/testing';
 import {expect} from '@jest/globals';
 import {ConfigService} from '@nestjs/config';
 /* Application Dependencies */
+import {mockGrpcModules} from '@server/test/grpc-esm-mocks';
 import {CredentialService} from '@server/modules/credential/credential.service';
 /* Local Dependencies */
-import {ClnService} from './cln.service.js';
-import * as grpc from '@grpc/grpc-js';
+import type {ClnService as ClnServiceType} from './cln.service.js';
+
+const {proto_loader, grpc} = await mockGrpcModules();
+const {ClnService} = await import('./cln.service.js');
 
 describe('ClnService', () => {
-	let clnService: ClnService;
+	let clnService: ClnServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let credentialService: jest.Mocked<CredentialService>;
 
@@ -22,7 +25,7 @@ describe('ClnService', () => {
 			],
 		}).compile();
 
-		clnService = module.get<ClnService>(ClnService);
+		clnService = module.get(ClnService);
 		configService = module.get(ConfigService);
 		credentialService = module.get(CredentialService);
 	});
@@ -55,12 +58,12 @@ describe('ClnService', () => {
 		});
 		credentialService.loadPemOrPath.mockReturnValue(Buffer.from('x'));
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		const loadPackageDefinition = jest.spyOn(grpc, 'loadPackageDefinition').mockReturnValue({cln: {Node: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({cln: {Node: jest.fn()}});
 		clnService.initializeLightningClient();
 		expect(createSsl).toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
-		expect(loadPackageDefinition).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
+		expect(grpc.loadPackageDefinition).toHaveBeenCalled();
 	});
 
 	it('mapClnInfo maps fields and uris correctly', async () => {

--- a/src/server/modules/lightning/lnd/lnd.service.spec.ts
+++ b/src/server/modules/lightning/lnd/lnd.service.spec.ts
@@ -3,13 +3,16 @@ import {Test, TestingModule} from '@nestjs/testing';
 import {expect} from '@jest/globals';
 import {ConfigService} from '@nestjs/config';
 /* Application Dependencies */
+import {mockGrpcModules} from '@server/test/grpc-esm-mocks';
 import {CredentialService} from '@server/modules/credential/credential.service';
 /* Local Dependencies */
-import {LndService} from './lnd.service.js';
-import * as grpc from '@grpc/grpc-js';
+import type {LndService as LndServiceType} from './lnd.service.js';
+
+const {proto_loader, grpc} = await mockGrpcModules();
+const {LndService} = await import('./lnd.service.js');
 
 describe('LndService', () => {
-	let lndService: LndService;
+	let lndService: LndServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let credentialService: jest.Mocked<CredentialService>;
 
@@ -22,7 +25,7 @@ describe('LndService', () => {
 			],
 		}).compile();
 
-		lndService = module.get<LndService>(LndService);
+		lndService = module.get(LndService);
 		configService = module.get(ConfigService);
 		credentialService = module.get(CredentialService);
 	});
@@ -56,17 +59,15 @@ describe('LndService', () => {
 		const createFromMetadataGenerator = jest.spyOn(grpc.credentials, 'createFromMetadataGenerator').mockReturnValue({} as any);
 		const createSsl = jest.spyOn(grpc.credentials, 'createSsl').mockReturnValue({} as any);
 		const combine = jest.spyOn(grpc.credentials, 'combineChannelCredentials').mockReturnValue({} as any);
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
-		const loadPackageDefinition = jest
-			.spyOn(grpc, 'loadPackageDefinition')
-			.mockReturnValue({lnrpc: {Lightning: jest.fn()}, walletrpc: {WalletKit: jest.fn()}} as any);
+		proto_loader.loadSync.mockReturnValue({});
+		grpc.loadPackageDefinition.mockReturnValue({lnrpc: {Lightning: jest.fn()}, walletrpc: {WalletKit: jest.fn()}});
 		lndService.initializeLightningClient();
 		lndService.initializeWalletKitClient();
 		expect(createFromMetadataGenerator).toHaveBeenCalled();
 		expect(createSsl).toHaveBeenCalled();
 		expect(combine).toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
-		expect(loadPackageDefinition).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
+		expect(grpc.loadPackageDefinition).toHaveBeenCalled();
 	});
 
 	it('mapLndRequest constructs a LightningRequest', () => {

--- a/src/server/modules/middleware/index-html.middleware.spec.ts
+++ b/src/server/modules/middleware/index-html.middleware.spec.ts
@@ -1,13 +1,14 @@
 import {Request, Response, NextFunction} from 'express';
-import {readFileSync} from 'fs';
+import type {readFileSync as ReadFileSync} from 'fs';
 
-import {indexHtml} from './index-html.middleware.js';
+// Core modules bypass the ESM mock registry unless replaced at the module level.
+jest.unstable_mockModule('fs', () => {
+	const readFileSync = jest.fn();
+	return {readFileSync, default: {readFileSync}};
+});
 
-jest.mock('fs', () => ({
-	readFileSync: jest.fn(),
-}));
-
-const mockedReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+const {readFileSync: mockedReadFileSync} = (await import('fs')) as unknown as {readFileSync: jest.MockedFunction<typeof ReadFileSync>};
+const {indexHtml} = await import('./index-html.middleware.js');
 
 describe('indexHtml', () => {
 	let req: Partial<Request>;

--- a/src/server/modules/tapass/tapd/tapd.service.spec.ts
+++ b/src/server/modules/tapass/tapd/tapd.service.spec.ts
@@ -3,13 +3,16 @@ import {Test, TestingModule} from '@nestjs/testing';
 import {expect} from '@jest/globals';
 import {ConfigService} from '@nestjs/config';
 /* Application Dependencies */
+import {mockGrpcModules} from '@server/test/grpc-esm-mocks';
 import {CredentialService} from '@server/modules/credential/credential.service';
 /* Local Dependencies */
-import {TapdService} from './tapd.service.js';
-import * as grpc from '@grpc/grpc-js';
+import type {TapdService as TapdServiceType} from './tapd.service.js';
+
+const {proto_loader, grpc} = await mockGrpcModules();
+const {TapdService} = await import('./tapd.service.js');
 
 describe('TapdService', () => {
-	let tapdService: TapdService;
+	let tapdService: TapdServiceType;
 	let configService: jest.Mocked<ConfigService>;
 	let credentialService: jest.Mocked<CredentialService>;
 
@@ -22,7 +25,7 @@ describe('TapdService', () => {
 			],
 		}).compile();
 
-		tapdService = module.get<TapdService>(TapdService);
+		tapdService = module.get(TapdService);
 		configService = module.get(ConfigService);
 		credentialService = module.get(CredentialService);
 	});
@@ -66,19 +69,17 @@ describe('TapdService', () => {
 		const combine = jest.spyOn(grpc.credentials, 'combineChannelCredentials').mockReturnValue({} as any);
 
 		// Mock loadPackageDefinition -> namespace and client constructor
-		const loadSync = jest.spyOn(require('@grpc/proto-loader'), 'loadSync').mockReturnValue({} as any);
+		proto_loader.loadSync.mockReturnValue({});
 		const client_ctor = jest.fn();
-		const loadPackageDefinition = jest
-			.spyOn(grpc, 'loadPackageDefinition')
-			.mockReturnValue({taprpc: {TaprootAssets: client_ctor}} as any);
+		grpc.loadPackageDefinition.mockReturnValue({taprpc: {TaprootAssets: client_ctor}});
 
 		tapdService.initializeTaprootAssetsClient();
 
 		expect(createFromMetadataGenerator).toHaveBeenCalled();
 		expect(createSsl).toHaveBeenCalled();
 		expect(combine).toHaveBeenCalled();
-		expect(loadSync).toHaveBeenCalled();
-		expect(loadPackageDefinition).toHaveBeenCalled();
+		expect(proto_loader.loadSync).toHaveBeenCalled();
+		expect(grpc.loadPackageDefinition).toHaveBeenCalled();
 		expect(client_ctor).toHaveBeenCalled();
 		metadata_add.mockRestore();
 	});

--- a/src/server/modules/user/user.service.spec.ts
+++ b/src/server/modules/user/user.service.spec.ts
@@ -3,16 +3,23 @@ import {Test, TestingModule} from '@nestjs/testing';
 /* Vendor Dependencies */
 import {getRepositoryToken} from '@nestjs/typeorm';
 import {expect} from '@jest/globals';
-import * as bcrypt from 'bcrypt';
 /* Local Dependencies */
-import {UserService} from './user.service.js';
+import type {UserService as UserServiceType} from './user.service.js';
 import {User} from './user.entity.js';
 import {UserRole} from './user.enums.js';
 
-jest.mock('bcrypt');
+// unstable_mockModule has no automock equivalent, so the surface the service uses is
+// stubbed explicitly.
+jest.unstable_mockModule('bcrypt', () => {
+	const mock = {compare: jest.fn(), hash: jest.fn()};
+	return {...mock, default: mock};
+});
+
+const bcrypt = (await import('bcrypt')) as any;
+const {UserService} = await import('./user.service.js');
 
 describe('UserService', () => {
-	let userService: UserService;
+	let userService: UserServiceType;
 	let mockRepository: any;
 
 	beforeEach(async () => {
@@ -28,7 +35,7 @@ describe('UserService', () => {
 			providers: [UserService, {provide: getRepositoryToken(User), useValue: mockRepository}],
 		}).compile();
 
-		userService = module.get<UserService>(UserService);
+		userService = module.get(UserService);
 	});
 
 	it('should be defined', () => {

--- a/src/server/test/esm-mode.spec.ts
+++ b/src/server/test/esm-mode.spec.ts
@@ -1,0 +1,13 @@
+/**
+ * Guards the ESM test harness.
+ *
+ * Without `--experimental-vm-modules`, jest silently ignores `extensionsToTreatAsEsm`,
+ * ts-jest emits CommonJS, and the whole suite passes without ever exercising ESM. This
+ * spec fails loudly in that case: `import.meta` is only valid in an ES module. The specs
+ * that use top-level await would also fail, but the other ~100 would silently pass as CJS.
+ */
+describe('ESM test harness', () => {
+	it('runs specs as real ES modules', () => {
+		expect(typeof import.meta.url).toBe('string');
+	});
+});

--- a/src/server/test/grpc-esm-mocks.ts
+++ b/src/server/test/grpc-esm-mocks.ts
@@ -1,0 +1,24 @@
+/**
+ * Replaces the gRPC modules for specs that construct a gRPC client.
+ *
+ * Under ESM a namespace import is sealed and its exports are snapshotted, so a top-level
+ * export cannot be spied — it has to be swapped at the module level. Nested objects such
+ * as `grpc.credentials` stay shared by reference and are still spy-able.
+ *
+ * Must be called before importing the service under test, and must never import the gRPC
+ * modules statically: that would evaluate the real ones before the mocks register.
+ */
+export async function mockGrpcModules(): Promise<{proto_loader: any; grpc: any}> {
+	jest.unstable_mockModule('@grpc/proto-loader', () => {
+		const actual = jest.requireActual('@grpc/proto-loader') as object;
+		return {...actual, loadSync: jest.fn(), default: actual};
+	});
+	jest.unstable_mockModule('@grpc/grpc-js', () => {
+		const actual = jest.requireActual('@grpc/grpc-js') as object;
+		return {...actual, loadPackageDefinition: jest.fn(), default: actual};
+	});
+	return {
+		proto_loader: (await import('@grpc/proto-loader')) as any,
+		grpc: (await import('@grpc/grpc-js')) as any,
+	};
+}

--- a/src/server/test/jest-esm-globals.ts
+++ b/src/server/test/jest-esm-globals.ts
@@ -1,0 +1,12 @@
+/**
+ * Exposes `jest` as a global for specs.
+ *
+ * Under ESM the `jest` object is no longer injected as a module-wrapper parameter, so it
+ * would otherwise have to be imported into every spec that uses it. Importing it also
+ * shadows the ambient `@types/jest` declarations, whose looser generics the existing mock
+ * call sites are written against. Assigning it here keeps both the runtime value and the
+ * ambient typing intact.
+ */
+import {jest} from '@jest/globals';
+
+Object.assign(globalThis, {jest});

--- a/src/server/test/jest-esm.d.ts
+++ b/src/server/test/jest-esm.d.ts
@@ -1,0 +1,4 @@
+/** @types/jest ships unstable_unmockModule but not its counterpart. */
+declare namespace jest {
+	function unstable_mockModule(module_name: string, factory: () => unknown, options?: {virtual?: boolean}): typeof jest;
+}

--- a/src/server/test/schema-guard.spec.ts
+++ b/src/server/test/schema-guard.spec.ts
@@ -1,6 +1,7 @@
 /* Core Dependencies */
 import {readdirSync, readFileSync} from 'fs';
-import {join} from 'path';
+import {join, dirname} from 'path';
+import {fileURLToPath} from 'url';
 
 /**
  * Ensures every onModuleInit / onApplicationBootstrap implementation
@@ -11,8 +12,10 @@ import {join} from 'path';
  * must check this flag and return early, otherwise the build can
  * hang or consume excessive memory on constrained hosts.
  */
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+
 describe('SCHEMA_ONLY guard', () => {
-	const MODULES_DIR = join(__dirname, '..', 'modules');
+	const MODULES_DIR = join(CURRENT_DIR, '..', 'modules');
 	const HOOK_PATTERN = /(?:async\s+)?(?:public\s+)?(?:async\s+)?on(?:ModuleInit|ApplicationBootstrap)\s*\(/;
 	const GUARD_PATTERN = /process\.env\.SCHEMA_ONLY/;
 
@@ -37,7 +40,7 @@ describe('SCHEMA_ONLY guard', () => {
 		for (const file of files) {
 			const content = readFileSync(file, 'utf-8');
 			if (HOOK_PATTERN.test(content) && !GUARD_PATTERN.test(content)) {
-				const relative = file.replace(join(__dirname, '..', '..', '..') + '/', '');
+				const relative = file.replace(join(CURRENT_DIR, '..', '..', '..') + '/', '');
 				missing.push(relative);
 			}
 		}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -25,5 +25,5 @@
     "esModuleInterop": true,
   },
   "include": ["src/server"],
-  "exclude": ["src/server/**/*.spec.ts"]
+  "exclude": ["src/server/**/*.spec.ts", "src/server/test/**"]
 }

--- a/tsconfig.server.spec.json
+++ b/tsconfig.server.spec.json
@@ -3,6 +3,8 @@
 {
   "extends": "./tsconfig.server.json",
   "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "outDir": "./out-tsc/spec",
     "types": [
       "jest",
@@ -12,5 +14,6 @@
   "include": [
     "src/server/**/*.spec.ts",
     "src/server/**/*.d.ts"
-  ]
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
## Changes

- **Server tests now run as native ESM** — jest switched to `--experimental-vm-modules` with `useESM` ts-jest, matching the existing swc-node ESM toolchain.
- **Spec mocking pattern updated for ESM** — specs that mocked modules (gRPC clients, `fs`, `bcrypt`, `better-sqlite3`, `pg`, `child_process`) now use `jest.unstable_mockModule` + dynamic import instead of `jest.mock`/`require`, since ESM namespace imports can't be spied directly.
- **New shared test helpers** — `grpc-esm-mocks.ts` centralizes gRPC module mocking across the lnd/cln/cdk/nutshell/tapd specs; `jest-esm-globals.ts` sets up ESM-only jest globals.
- **CI now typechecks specs** — a new `typecheck:spec` script (`tsc --noEmit` against `tsconfig.server.spec.json`) runs in CI and in a new consolidated `ci` npm script, catching spec-only type errors that previously only surfaced in an editor.

## Testing

- No behavior changes; this is test-infrastructure-only. Verify by running `npm run test:server` and `npm run typecheck:spec` locally.